### PR TITLE
Adjusted fullscreen icon for windows users

### DIFF
--- a/ide/static/ide/css/ide.css
+++ b/ide/static/ide/css/ide.css
@@ -150,7 +150,7 @@ span.cm-autofilled-end {
 
 .fullscreen-icon {
     position: absolute;
-    right: 10px;
+    right: 25px;
     top: 10px;
     cursor: pointer;
     z-index: 3;
@@ -180,7 +180,7 @@ span.cm-autofilled-end {
     display:none;
     color: #aaa;
     position: absolute;
-    right: 20px;
+    right: 35px;
     width: 120px;
     top: 7px;
     font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;


### PR DESCRIPTION
The Windows versions of Chrome, IE10 and Firefox are displaying the scroll bars over part of the fullscreen button, which makes it difficult to click.

Before:
![fullscreen_icon_bug](https://f.cloud.github.com/assets/137686/1976427/49e741e0-838a-11e3-9ba2-dd4cfcf55ce5.png)

After:
![fullscreen_icon_bug_after](https://f.cloud.github.com/assets/137686/1976426/476a5c36-838a-11e3-99e0-484f7da5ae40.png)
