### PR TITLE
Fixed autocomplete not showing in fullscreen mode

### DIFF
--- a/ide/static/ide/css/ide.css
+++ b/ide/static/ide/css/ide.css
@@ -8,6 +8,7 @@
 
 .CodeMirror-hints {
   font-family: Menlo, 'Deja Vu Sans Mono', monospace;
+  z-index: 10001; /* Needs to be higher than the z-index of .CodeMirror.FullScreen */
 }
 
 .edit-resource-regex, #settings-app-keys {


### PR DESCRIPTION
Autocomplete was being hidden because of the z-index on the Fullscreen class. I added a z-index to .CodeMirror-hints just a smidgeon higher than editor so it can overlay properly.

![Fullscreen Autocomplete In Action](https://f.cloud.github.com/assets/137686/1990513/b57c3446-8485-11e3-94bb-86142cf5773b.png)
