### PR TITLE
Use valid version string for version field placeholder

### DIFF
--- a/ide/templates/ide/project/settings.html
+++ b/ide/templates/ide/project/settings.html
@@ -72,7 +72,7 @@
                 <div class="control-group">
                     <label class="control-label" for="settings-version-label">Version label</label>
                     <div class="controls">
-                        <input type="text" id="settings-version-label" placeholder="0.1.2" value="{{project.app_version_label}}"
+                        <input type="text" id="settings-version-label" placeholder="0.1" value="{{project.app_version_label}}"
                                 pattern="^(\d{1,2}|1\d{2}|2[0-4]\d|25[0-5])(\.(\d{1,2}|1\d{2}|2[0-4]\d|25[0-5]))?$">
                         <span class="help-block">
                             App version. Takes the format major[.minor], where major and minor are between 0 and 255.


### PR DESCRIPTION
The placeholder value of "0.1.2" is misleading because it implies that the correct format is X.Y.Z but in fact only "X" or "X.Y" are valid version formats. "0.1" is a more helpful placeholder.
