### PR TITLE
Update qemu-enter-token.html to use "tel" input type, instead of "text"

### DIFF
--- a/ide/static/ide/css/mobile.css
+++ b/ide/static/ide/css/mobile.css
@@ -31,14 +31,6 @@ h2 {
     height: 40px;
     position: absolute;
     left: 20px;
-    font-family: PFD-Light,'Helvetica Neue',Helvetica,Arial,sans-serif;
-    border: none;
-    border-radius: 10px;
-    padding-top: 5px;
-    padding-left: 15px;
-    margin: 0;
-    padding-right: 0;
-    padding-bottom: 0
 }
 
 .content .btn {

--- a/ide/static/ide/css/mobile.css
+++ b/ide/static/ide/css/mobile.css
@@ -31,6 +31,14 @@ h2 {
     height: 40px;
     position: absolute;
     left: 20px;
+    font-family: PFD-Light,'Helvetica Neue',Helvetica,Arial,sans-serif;
+    border: none;
+    border-radius: 10px;
+    padding-top: 5px;
+    padding-left: 15px;
+    margin: 0;
+    padding-right: 0;
+    padding-bottom: 0
 }
 
 .content .btn {

--- a/ide/templates/ide/qemu-enter-token.html
+++ b/ide/templates/ide/qemu-enter-token.html
@@ -34,7 +34,7 @@ window.addEventListener('load', function() {
         <!-- I still don't know how to vertically centre things with CSS. -->
         <h2>Enter code</h2>
         <form>
-            <input id="code-input" type="text" pattern="\d*" maxlength="6">
+            <input id="code-input" type="tel" pattern="\d*" maxlength="6">
             <p><button class="btn btn-primary" id="go-btn" disabled>Go</button></p>
         </form>
         {% if failed %}

--- a/root/static/common/css/common.css
+++ b/root/static/common/css/common.css
@@ -331,7 +331,7 @@ select {
     background-image: url('../../common/img/dropdown.png');
 }
 
-input[type=text], input[type=number], input[type=password] {
+input[type=text], input[type=number], input[type=password], input[type=tel] {
     height: 35px;
     font-family: PFD-Light, 'Helvetica Neue', Helvetica, Arial, sans-serif;
     font-size: larger;


### PR DESCRIPTION
Allows for much more convenient mobile input of the purely numerical code.

On mobile, the "tel" input type instructs the keyboard to default to numerical input.
With the "text" input type the normal keyboard is displayed. More buttons have to be pressed to be able to input numeric values.