### PR TITLE
If using tabs, comment commands don't work

### DIFF
--- a/ide/static/ide/js/editor.js
+++ b/ide/static/ide/js/editor.js
@@ -141,13 +141,13 @@ CloudPebble.Editor = (function() {
                         }
                         return CodeMirror.Pass;
                     };
-                    settings.extraKeys['Cmd-/'] = function(cm) {
-                        CodeMirror.commands.toggleComment(cm);
-                    };
-                    settings.extraKeys['Ctrl-/']  = function(cm) {
-                        CodeMirror.commands.toggleComment(cm);
-                    };
                 }
+                settings.extraKeys['Cmd-/'] = function(cm) {
+                    CodeMirror.commands.toggleComment(cm);
+                };
+                settings.extraKeys['Ctrl-/']  = function(cm) {
+                    CodeMirror.commands.toggleComment(cm);
+                };
                 if(is_js) {
                     settings.gutters = ['gutter-hint-warnings', 'CodeMirror-linenumbers'];
                 } else {


### PR DESCRIPTION
While working with a watchface, I found my way to a [list of shortcuts for cloudpebble](https://www.reddit.com/r/pebble/comments/32kntz/cloudpebble_keyboard_shortcuts/) and saw there was one for comment/uncomment line. I immediately tried it out and found that it did not work. 

I dove into the source code provided as reference for the shortcut lists and saw that only those who have spaces instead of tabs get that command. I know that tabs vs spaces is one of the oldest holy wars in existence, but unless there is a technical reason for this not to be available to those of us who prefer tabs, I'd love to see this merged.