### PR TITLE
PBL-21221 Migrate CloudPebble's ycm connection to use websockets instead of XHR

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,6 +7,8 @@ Vagrant.configure("2") do |config|
   config.vm.network :forwarded_port, host: 8002, guest: 8002
   config.vm.network "private_network", ip: "192.168.42.42"
 
+  config.vm.synced_folder "../ycmd-proxy", "/home/vagrant/ycmd-proxy"
+
   config.vm.provider "virtualbox" do |v|
     v.memory = 3192
     v.cpus = 4

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,8 +7,6 @@ Vagrant.configure("2") do |config|
   config.vm.network :forwarded_port, host: 8002, guest: 8002
   config.vm.network "private_network", ip: "192.168.42.42"
 
-  config.vm.synced_folder "../ycmd-proxy", "/home/vagrant/ycmd-proxy"
-
   config.vm.provider "virtualbox" do |v|
     v.memory = 3192
     v.cpus = 4

--- a/ide/api/ycm.py
+++ b/ide/api/ycm.py
@@ -61,7 +61,7 @@ def _spin_up_server(request):
             if result.ok:
                 response = result.json()
                 if response['success']:
-                    return json_response({'uuid': response['uuid'], 'server': server})
+                    return json_response({'uuid': response['uuid'], 'server': server, 'secure': response['secure']})
         except (requests.RequestException, ValueError):
             import traceback
             traceback.print_exc()

--- a/ide/api/ycm.py
+++ b/ide/api/ycm.py
@@ -8,6 +8,7 @@ from ide.api import json_response, json_failure
 from ide.models.project import Project
 import requests
 import random
+import urlparse
 
 __author__ = 'katharine'
 

--- a/ide/api/ycm.py
+++ b/ide/api/ycm.py
@@ -4,13 +4,16 @@ from django.contrib.auth.decorators import login_required
 from django.shortcuts import get_object_or_404
 from django.views.decorators.http import require_POST
 from django.views.decorators.csrf import csrf_exempt
+from urlparse import urlparse
+
 from ide.api import json_response, json_failure
 from ide.models.project import Project
 import requests
 import random
-import urlparse
+
 
 __author__ = 'katharine'
+
 
 @login_required
 @require_POST
@@ -61,7 +64,11 @@ def _spin_up_server(request):
             if result.ok:
                 response = result.json()
                 if response['success']:
-                    return json_response({'uuid': response['uuid'], 'server': server, 'secure': response['secure']})
+                    secure = response['secure']
+                    scheme = "wss" if secure else "ws"
+                    ws_server = urlparse(server)._replace(scheme=scheme).geturl()
+                    return json_response({'uuid': response['uuid'], 'server': ws_server, 'secure': secure})
+
         except (requests.RequestException, ValueError):
             import traceback
             traceback.print_exc()

--- a/ide/static/ide/js/editor.js
+++ b/ide/static/ide/js/editor.js
@@ -760,10 +760,8 @@ CloudPebble.Editor = (function() {
         }
         $.post("/ide/project/" + PROJECT_ID + "/create_source_file", params, function(data) {
             if(data.success) {
-                CloudPebble.YCM.createFile(data.file, params.content)
-                    .always(function() {
-                        add_source_file(data.file);
-                    });
+                CloudPebble.YCM.createFile(data.file, params.content);
+                add_source_file(data.file);
             }
             if(callback) {
                 callback(data);

--- a/ide/static/ide/js/ycm.js
+++ b/ide/static/ide/js/ycm.js
@@ -138,10 +138,10 @@ CloudPebble.YCM = new (function() {
                     $('.prepare-autocomplete').hide();
                     $('.footer-credits').show();
                     mInitialised = true;
+                    mRestarting = false;
                 }
             }).fail(function() {
                 mFailed = true;
-                console.log('restart failed.');
                 $('.prepare-autocomplete').text(gettext("Code completion resync failed."));
                 throw "Restart failed";
             });
@@ -176,12 +176,9 @@ CloudPebble.YCM = new (function() {
                             $('.footer-credits').show();
                         }
                     });
-                    // TODO: test socket close/error restart
-                    mSocket.on('close', function() {
-                        self.restart();
-                    });
-                    mSocket.on('error', function() {
-                        self.restart();
+
+                    mSocket.on('close error', function() {
+                        setTimeout(function() {self.restart();}, 1000);
                     });
 
                     mSocket.connect();

--- a/ide/static/ide/js/ycm.js
+++ b/ide/static/ide/js/ycm.js
@@ -1,4 +1,105 @@
 CloudPebble = CloudPebble || {};
+
+// This is a drop-in replacement for $.ajax
+// TODO: is this overkill? It seems to work, and means that very few changes to other code are required.
+// TODO: If we do keep this, (a) stick it in another file, (b) make sure it's robust
+var EventedWebSocket = function(host) {
+    var self = this;
+    var mSocket = null;
+    var ids = {};
+
+    _.extend(this, Backbone.Events);
+
+    this.getSocket = function() {
+        return mSocket;
+    };
+
+    this.connect = function() {
+        mSocket = new WebSocket(host);
+        mSocket.onerror = handle_socket_error;
+        mSocket.onclose = handle_socket_close;
+        mSocket.onmessage = handle_socket_message;
+        mSocket.onopen = handle_socket_open;
+    };
+
+    this.close = function() {
+        mSocket.close();
+        mSocket = null;
+    };
+
+    var register_promise = function(promise) {
+        var id;
+        for (id = 0; id in ids; id++);
+        ids[id] = promise;
+        return id;
+    };
+
+    var trigger_promise = function(id, data) {
+        var promise = ids[id];
+        delete ids[id];
+        // TODO: think about other failure conditions
+        if ('success' in data && data['success'] == false) {
+            promise.reject(data);
+        }
+        else {
+            promise.resolve(data);
+        }
+    };
+
+    this.send = function(data) {
+        var d = $.Deferred();
+        data._ws_message_id = register_promise(d);
+        var text = JSON.stringify(data);
+        mSocket.send(text);
+        return d.promise();
+    };
+
+    this.sendTimeout = function(data, timeout) {
+        var d = $.Deferred();
+        var id = register_promise(d);
+        data._ws_message_id = id;
+        var text = JSON.stringify(data);
+        mSocket.send(text);
+        setTimeout(function() {
+            d.reject({'error': 'timed out'});
+            delete ids[id];
+        }, timeout);
+        return d.promise();
+    }
+
+    this.isOpen = function() {
+        return (mSocket.readyState == WebSocket.OPEN);
+    };
+
+    var handle_socket_error = function(e) {
+        // TODO: actually handle errors somewhere
+        self.trigger('error', e);
+    };
+
+    var handle_socket_open = function() {
+        self.trigger('open');
+    };
+
+    var handle_socket_close = function(e) {
+        self.trigger('close', e);
+        // TODO: actually handle socket closures (e.g. attempt a restart)
+        mSocket = null;
+        _.each(ids, function(promise, key) {
+            promise.reject({'error': 'socket closed'})
+        });
+        ids = {};
+    };
+
+    var handle_socket_message = function(e) {
+        var data = JSON.parse(e.data);
+        var id = data._ws_message_id;
+        if (id in ids) {
+            trigger_promise(id, data);
+        }
+        // if id is not in ids, the message probably timed out.
+    };
+};
+
 CloudPebble.YCM = new (function() {
     var self = this;
     var PING_INTERVAL = 90000;
@@ -8,16 +109,24 @@ CloudPebble.YCM = new (function() {
     var mFailed = false;
     var mRestarting = false;
     var mURL = null;
+    var mSocket = null;
     var mUUID = null;
     var mPingTimer = null;
 
     function pingServer() {
-        $.ajax(mURL + '/ping', {
-            contentType: 'application/json',
-            method: 'POST'
-        }).always(function() {
+        ws_send('ping',{}).always(function() {
             mPingTimer = _.delay(pingServer, PING_INTERVAL);
         });
+    }
+
+    function ws_send(command, data) {
+        data['command'] = command;
+        return mSocket.send(data);
+    }
+
+    function ws_send_timeout(command, timeout, data) {
+        data['command'] = command;
+        return mSocket.sendTimeout(data, timeout);
     }
 
     function sendBuffers() {
@@ -28,13 +137,9 @@ CloudPebble.YCM = new (function() {
             editor.patch_sequence = 0;
             ++pending;
 
-            $.ajax(mURL + '/create', {
-                data: JSON.stringify({
+            ws_send('create', {
                     filename: editor.file_path,
                     content: editor.getValue()
-                }),
-                contentType: 'application/json',
-                method: 'POST'
             }).done(function() {
                 if(--pending == 0) {
                     console.log('restart done.');
@@ -65,14 +170,21 @@ CloudPebble.YCM = new (function() {
                 if(data.success) {
                     mUUID = data.uuid;
                     mURL = data.server + 'ycm/' + data.uuid;
-                    if(mRestarting) {
-                        sendBuffers();
-                    } else {
-                        mInitialised = true;
-                        mPingTimer = _.delay(pingServer, PING_INTERVAL);
-                        $('.prepare-autocomplete').hide();
-                        $('.footer-credits').show();
-                    }
+                    // TODO: deal with wss. Also, parse URLs properly.
+                    mSocketHost = "ws://"+mURL.split("://")[1]+"/ws";
+                    mSocket = new EventedWebSocket(mSocketHost);
+                    mSocket.on('open', function() {
+                        if(mRestarting) {
+                            sendBuffers();
+                        } else {
+                            mInitialised = true;
+                            mPingTimer = _.delay(pingServer, PING_INTERVAL);
+                            $('.prepare-autocomplete').hide();
+                            $('.footer-credits').show();
+                        }
+                    });
+                    // TODO: deal with closed/errored websocket
+                    mSocket.connect();
                 } else {
                     mFailed = true;
                     $('.prepare-autocomplete').text(gettext("Code completion unavailable."));
@@ -95,6 +207,7 @@ CloudPebble.YCM = new (function() {
         mFailed = false;
         mRestarting = true;
         mURL = false;
+        mSocket = null;
         mUUID = null;
         $('.prepare-autocomplete').text(gettext("Code completion lost; retrying...")).show();
         $('.footer-credits').hide();
@@ -111,12 +224,8 @@ CloudPebble.YCM = new (function() {
             promise.reject();
             return promise.promise();
         }
-        $.ajax(mURL + '/delete', {
-            data: JSON.stringify({
+        ws_send('delete', {
                 filename: ((file.target == 'worker') ? 'worker_src/' : 'src/') + file.name
-            }),
-            contentType: 'application/json',
-            method: 'POST'
         }).done(function() {
             promise.resolve();
         }).fail(function() {
@@ -131,13 +240,9 @@ CloudPebble.YCM = new (function() {
             promise.reject();
             return promise.promise();
         }
-        $.ajax(mURL + '/create', {
-            data: JSON.stringify({
+        ws_send('create', {
                 filename: ((file.target == 'worker') ? 'worker_src/' : 'src/') + file.name,
                 content: content || ''
-            }),
-            contentType: 'application/json',
-            method: 'POST'
         }).done(function() {
             promise.resolve();
         }).fail(function() {
@@ -165,13 +270,9 @@ CloudPebble.YCM = new (function() {
             }
         });
         defines.push("");
-        $.ajax(mURL + '/create', {
-            data: JSON.stringify({
+        ws_send('create',{
                 filename: 'build/src/resource_ids.auto.h',
                 content: defines.join("\n")
-            }),
-            contentType: 'application/json',
-            method: 'POST'
         });
     };
 
@@ -185,25 +286,21 @@ CloudPebble.YCM = new (function() {
         cursor = cursor || editor.getCursor();
         var these_patches = editor.patch_list;
         editor.patch_list = [];
-        $.ajax(mURL + '/' + endpoint, {
-            data: JSON.stringify({
-                file: editor.file_path,
-                line: cursor.line,
-                ch: cursor.ch,
-                patches: these_patches
-            }),
-            contentType: 'application/json',
-            method: 'POST',
-            timeout: 2000
+        ws_send_timeout(endpoint, 2000, {
+            file: editor.file_path,
+            line: cursor.line,
+            ch: cursor.ch,
+            patches: these_patches
         }).done(function(data) {
             promise.resolve(data);
-        }).fail(function(xhr) {
+        }).fail(function(error) {
             editor.patch_list = these_patches.concat(editor.patch_list);
             promise.reject();
-            // If we get a 404 status our session is definitively lost and we should create another.
-            if(xhr.status == 404) {
-                self.restart();
-            }
+            // TODO: rework this logic for websockets
+            //// If we get a 404 status our session is definitively lost and we should create another.
+            //if(xhr.status == 404) {
+            //    self.restart();
+            //}
         });
         return promise.promise();
     };

--- a/ide/static/ide/js/ycm.js
+++ b/ide/static/ide/js/ycm.js
@@ -143,7 +143,6 @@ CloudPebble.YCM = new (function() {
             }).fail(function() {
                 mFailed = true;
                 $('.prepare-autocomplete').text(gettext("Code completion resync failed."));
-                throw "Restart failed";
             });
         });
     }
@@ -288,10 +287,11 @@ CloudPebble.YCM = new (function() {
             line: cursor.line,
             ch: cursor.ch,
             patches: these_patches
-        }, 2000).done(function(data) {
+        }).done(function(data) {
             promise.resolve(data);
         }).fail(function(error) {
-            editor.patch_list = these_patches.concat(editor.patch_list);
+            console.log("Patches rejected");
+            // editor.patch_list = these_patches.concat(editor.patch_list);
             promise.reject();
             // TODO: we moved the restart logic out of here. When that gets tested, remove this TODO.
         });

--- a/ide/static/ide/js/ycm.js
+++ b/ide/static/ide/js/ycm.js
@@ -140,8 +140,8 @@ CloudPebble.YCM = new (function() {
                 if(data.success) {
                     mUUID = data.uuid;
                     mURL = data.server + 'ycm/' + data.uuid;
-                    // TODO: deal with wss://. Also, parse URLs properly?
-                    mSocketHost = "ws://"+mURL.split("://")[1]+"/ws";
+                    mSocketHost = data.secure ? 'wss' : 'ws';
+                    mSocketHost += "://"+mURL.split("://")[1]+"/ws";
                     mSocket = new EventedWebSocket(mSocketHost);
                     mSocket.on('open', function() {
                         if(mRestarting) {


### PR DESCRIPTION
'First draft' of the switch to websockets for ycm-proxy. 

I originally added EventedWebSocket as a drop-in replacement for $.ajax, but I think it might actually be a generally OK approach. 

There are some TODOs left over:
- Deciding if the EventedWebSocket thing really is a good idea
- Option to move EventedWebSocket out to another file
- Decision on whether to support wss://  (the proxy would need to be updated too)

