### PR TITLE
PBL-20878 GitHub import doesn't appear to like ~bw and ~color

### DIFF
--- a/ide/templates/ide/project/resource.html
+++ b/ide/templates/ide/project/resource.html
@@ -33,7 +33,7 @@
         </div>
         <div class="well">
             <div class="control-group image-resource-preview variant-0 hide">
-                <label class="control-label">{% trans 'Black & White' %}</label>
+                <label class="control-label">{% trans 'Generic' %}</label>
                 <div class="controls">
                     <img src="">
                     <p>52x52</p>

--- a/ide/templates/ide/project/resource.html
+++ b/ide/templates/ide/project/resource.html
@@ -39,6 +39,13 @@
                     <p>52x52</p>
                 </div>
             </div>
+            <div class="control-group image-resource-preview variant-1 hide">
+                <label class="control-label">{% trans 'Black & White' %}</label>
+                <div class="controls">
+                    <img src="">
+                    <p>52x52</p>
+                </div>
+            </div>
             <div class="control-group image-resource-preview variant-2 hide">
                 <label class="control-label">{% trans 'Colour' %}</label>
                 <div class="controls">


### PR DESCRIPTION
This PR fixes #133 by also checking for ~bw and ~color versions of resources when a non-suffixed version is mentioned in the resource manifest.

Things tested to work:
- Importing, building and running the tea-timer example for colour pebble time
- Making a default pebble.js project on cloudpebble.net and adding a colour+bw resource, pushing it to github, importing it on my local cloudpebble, building and running it.

At the moment, in the unlikely event that a project has bw/color *and* 'default' variants of a file, all three would show up in the editor. This might not be perfect, but it's an improvement on the current state.