### PR TITLE
PBL-21985 Cloudpebble editor doesn't autofocus properly

### DIFF
--- a/ide/static/ide/js/editor.js
+++ b/ide/static/ide/js/editor.js
@@ -341,6 +341,8 @@ CloudPebble.Editor = (function() {
                         }
                     });
                     code_mirror.force_fold_lines(data.folded_lines);
+                    // This is needed to force focus on the editor
+                    setTimeout(function() { code_mirror.focus();}, 1);
                 }
 
                 function update_patch_list(instance, changes) {


### PR DESCRIPTION
This ensures the CloudPebble editor grabs focus when opening a file.