### PR TITLE
Stop emacs keybind warning from overflowing.

### DIFF
--- a/root/static/common/css/common.css
+++ b/root/static/common/css/common.css
@@ -406,6 +406,10 @@ input[type=checkbox]:checked {
     width: 435px;
 }
 
+.editor-settings .help-block {
+    width: inherit;
+}
+
 .nav-tabs {
     list-style: none;
     padding: 0;


### PR DESCRIPTION
The warning text for the emacs keybinding in the user settings page overflows outside the form's box - this fixes that.