### PR TITLE
PBL-21950 Auto-save changes to Settings page

### DIFF
--- a/ide/static/ide/css/ide.css
+++ b/ide/static/ide/css/ide.css
@@ -1003,3 +1003,19 @@ span.cm-autofilled-end {
 .padded-modal-header {
     padding: 10px 25px 10px 10px;
 }
+
+.settings-status-icons {
+    position: relative;
+    top: 10px;
+    float: right;
+}
+.settings-status-icons span {
+    background-image: url("../../common/img/glyphicons-halflings-white.png");
+}
+
+.fixed-well {
+  position: fixed;
+  width: 300px !important;
+  margin-left: 200px !important;
+  margin-top: -30px !important;
+}

--- a/ide/static/ide/css/ide.css
+++ b/ide/static/ide/css/ide.css
@@ -1004,18 +1004,3 @@ span.cm-autofilled-end {
     padding: 10px 25px 10px 10px;
 }
 
-.settings-status-icons {
-    position: relative;
-    top: 10px;
-    float: right;
-}
-.settings-status-icons span {
-    background-image: url("../../common/img/glyphicons-halflings-white.png");
-}
-
-.fixed-well {
-  position: fixed;
-  width: 300px !important;
-  margin-left: 200px !important;
-  margin-top: -30px !important;
-}

--- a/ide/static/ide/js/live_settings_form.js
+++ b/ide/static/ide/js/live_settings_form.js
@@ -1,0 +1,93 @@
+function make_live_settings_form(options) {
+    // Set up default options for the live settings form
+    var opts = _.defaults(options || {}, {
+        save_function: null,
+        form: null,
+        error_function: console.log,
+        control_selector: 'input, select',
+        changeable_control_selector: 'input',
+        label_selector: '.control-group label',
+        group_selector: '.control-group'
+    });
+    if (!_.isFunction(opts.save_function)
+        || (!_.isObject(opts.form))
+        || (!_.isFunction(opts.error_function))) {
+        throw "Invalid arguments to make_live_settings_form";
+    }
+
+    // Add status icons to every form element
+    $("<span class='settings-status-icons'>" +
+        "<span class='icon-ok setting-saved'></span>" +
+        "<span class='icon-edit setting-changed'></span>" +
+        "</span>")
+        .insertAfter(opts.form.find(opts.label_selector))
+        .children().hide();
+
+
+    var clear_changed_icons = function() {
+        // Replace all visible changed icons with a one-second 'tick'
+        opts.form.find('.setting-changed:visible').siblings('.setting-saved').show().delay(1000).hide('fast');
+        opts.form.find('.setting-changed').hide();
+    };
+
+    var flash_tick_icon = function(element) {
+        // Show the 'tick' icon for an element for one second
+        element.parents(opts.group_selector).find('.setting-saved').show().delay(1000).hide('fast');
+    };
+
+    var show_changed_icon = function(element) {
+        // Show the 'changed' icon for an element
+        element.parents(opts.group_selector).find('.setting-changed').show('fast');
+    };
+
+    // Set up a hook for any changed form elements
+    opts.form.find(opts.control_selector).change(function() {
+        var self = this;
+        // After the form is saved, flash the 'tick' icon on success or keep a 'changed' icon on error.
+        opts.save_function()
+            .done(function() {
+                clear_changed_icons();
+                flash_tick_icon($(self));
+            })
+            .fail(function(error) {
+                opts.error_function(error);
+                show_changed_icon($(self));
+            });
+    });
+
+    // While typing in text forms, show the changed icon
+    opts.form.find(opts.changeable_control_selector).on('input', function() {
+        show_changed_icon($(this));
+    });
+
+    // When a form-reset button is clicked, submit the form instantly
+    $(opts.form).bind("reset", function() {
+        var values = {};
+        // Keep track of the previous values of all form elements
+        opts.form.find(opts.control_selector).each(function() {
+           values[this.id] = $(this).val();
+        });
+
+        setTimeout(function() {
+            var func = null;
+            // After saving, show 'tick' or 'changed' icons for all modified settings.
+            opts.save_function()
+                .done(function() {
+                    clear_changed_icons();
+                    func = flash_tick_icon;
+                })
+                .fail(function(error) {
+                    opts.error_function(error);
+                    func = show_changed_icon;
+                })
+                .always(function() {
+                    opts.form.find(opts.control_selector).each(function() {
+                        if (_.has(values, this.id) && values[this.id] !== $(this).val()) {
+                            func($(this));
+                        }
+                    });
+                });
+        });
+
+    });
+}

--- a/ide/static/ide/js/settings.js
+++ b/ide/static/ide/js/settings.js
@@ -132,8 +132,6 @@ CloudPebble.Settings = (function() {
                     CloudPebble.ProjectInfo.sdk_version = sdk_version;
                     $('.project-name').text(name);
                     window.document.title = "CloudPebble – " + name;
-                    pane.find('.setting-changed:visible').siblings('.setting-saved').show().delay(1000).hide('fast');
-                    pane.find('.setting-changed').hide();
                     defer.resolve();
                 } else {
                     defer.reject(interpolate(gettext("Error: %s"), [error]));
@@ -146,25 +144,10 @@ CloudPebble.Settings = (function() {
             return defer.promise();
         };
 
-        $("<span class='settings-status-icons'>" +
-            "<span class='icon-ok setting-saved'></span>" +
-            "<span class='icon-edit setting-changed'></span>" +
-            "</span>")
-            .insertAfter(pane.find('.control-label'))
-            .children().hide();
-
-        pane.find('input, select').change(function() {
-            var self = this;
-            save().then(function() {
-                $(self).parents('.control-group').find('.setting-saved').show().delay(1000).hide('fast');
-            }, function(error) {
-                display_error(error);
-                $(self).parents('.control-group').find('.setting-changed').show('fast');
-            });
-        });
-
-        pane.find('input').on('input', function(ininin) {
-            $(this).parents('.control-group').find('.setting-changed').show('fast');
+        make_live_settings_form({
+            save_function: save,
+            error_function: display_error,
+            form: pane.find('form')
         });
 
         pane.find('#project-delete').click(function() {

--- a/ide/static/ide/js/settings.js
+++ b/ide/static/ide/js/settings.js
@@ -16,20 +16,15 @@ CloudPebble.Settings = (function() {
         }
 
         var display_error = function(message) {
-            $('#main-pane')[0].scrollTop = 0;
             pane.find('.alert').addClass('alert-error').removeClass('hide').text(message);
-            pane.find('input, button, select').removeAttr('disabled');
-        };
-
-        var display_success = function(message) {
-            $('#main-pane')[0].scrollTop = 0;
-            pane.find('.alert').addClass('alert-success').removeClass('hide').text(message);
             pane.find('input, button, select').removeAttr('disabled');
         };
 
         pane.find('#settings-name').val(CloudPebble.ProjectInfo.name);
         pane.find('form').submit(function(e) {e.preventDefault();});
-        pane.find('#project-save').click(function() {
+
+        var save = function() {
+            var defer = $.Deferred();
             var name = pane.find('#settings-name').val();
             var sdk_version = pane.find('#settings-sdk-version').val();
             var short_name = pane.find('#settings-short-name').val();
@@ -54,46 +49,36 @@ CloudPebble.Settings = (function() {
             app_capabilities = app_capabilities.join(',');
 
             if(name.replace(/\s/g, '') === '') {
-                display_error(gettext("You must specify a project name"));
-                return;
+                return defer.reject(gettext("You must specify a project name"));
             }
-
-
-            pane.find('input, button, select').attr('disabled', 'disabled');
 
             var saved_settings = {
                 'name': name
             };
 
             if(short_name.replace(/\s/g, '') == '') {
-                display_error(gettext("You must specify a short name."));
-                return;
+                return defer.reject(gettext("You must specify a short name."));
             }
             if(long_name.replace(/\s/g, '') == '') {
-                display_error(gettext("You must specify a long name."));
-                return;
+                return defer.reject(gettext("You must specify a long name."));
             }
             if(company_name.replace(/\s/g, '') == '') {
-                display_error(gettext("You must specify a company name."));
-                return;
+                return defer.reject(gettext("You must specify a company name."));
             }
             // This is not an appropriate use of a regex, but we have to have it for the HTML5 pattern attribute anyway,
             // so we may as well reuse the effort here.
             // It validates that the format matches x[.y] with x, y in [0, 255].
             if(!version_label.match(/^(\d{1,2}|1\d{2}|2[0-4]\d|25[0-5])(\.(\d{1,2}|1\d{2}|2[0-4]\d|25[0-5]))?$/)) {
-                display_error(gettext("You must specify a valid version number."));
-                return;
+                return defer.reject(gettext("You must specify a valid version number."));
             }
             if(!app_uuid.match(/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}/)) {
-                display_error(gettext("You must specify a valid UUID (of the form 00000000-0000-0000-0000-000000000000)"));
-                return;
+                return defer.reject(gettext("You must specify a valid UUID (of the form 00000000-0000-0000-0000-000000000000)"));
             }
 
 
             if(sdk_version == '3') {
                 if (!build_aplite && !build_basalt) {
-                    display_error(gettext("You must build your app for at least one platform."));
-                    return;
+                    return defer.reject(gettext("You must build your app for at least one platform."));
                 }
             }
 
@@ -132,7 +117,6 @@ CloudPebble.Settings = (function() {
             saved_settings['app_platforms'] = app_platforms;
 
             $.post('/ide/project/' + PROJECT_ID + '/save_settings', saved_settings, function(data) {
-                pane.find('input, button, select').removeAttr('disabled');
                 pane.find('.alert').removeClass("alert-success alert-error").addClass("hide");
                 if(data.success) {
                     CloudPebble.ProjectInfo.name = name;
@@ -148,13 +132,39 @@ CloudPebble.Settings = (function() {
                     CloudPebble.ProjectInfo.sdk_version = sdk_version;
                     $('.project-name').text(name);
                     window.document.title = "CloudPebble – " + name;
-                    display_success(gettext("Settings saved."));
+                    pane.find('.setting-changed:visible').siblings('.setting-saved').show().delay(1000).hide('fast');
+                    pane.find('.setting-changed').hide();
+                    defer.resolve();
                 } else {
-                    display_error(interpolate(gettext("Error: %s"), [data.error]));
+                    defer.reject(interpolate(gettext("Error: %s"), [error]));
                 }
+            }).fail(function(e) {
+                defer.reject(interpolate("Failed to save project settings. (%s) %s", [e.status, e.statusText]));
             });
 
             ga('send', 'event', 'project', 'save settings');
+            return defer.promise();
+        };
+
+        $("<span class='settings-status-icons'>" +
+            "<span class='icon-ok setting-saved'></span>" +
+            "<span class='icon-edit setting-changed'></span>" +
+            "</span>")
+            .insertAfter(pane.find('.control-label'))
+            .children().hide();
+
+        pane.find('input, select').change(function() {
+            var self = this;
+            save().then(function() {
+                $(self).parents('.control-group').find('.setting-saved').show().delay(1000).hide('fast');
+            }, function(error) {
+                display_error(error);
+                $(self).parents('.control-group').find('.setting-changed').show('fast');
+            });
+        });
+
+        pane.find('input').on('input', function(ininin) {
+            $(this).parents('.control-group').find('.setting-changed').show('fast');
         });
 
         pane.find('#project-delete').click(function() {
@@ -243,6 +253,7 @@ CloudPebble.Settings = (function() {
         pane.find('#uuid-generate').click(function() {
             var uuid_field = settings_template.find('#settings-uuid');
             uuid_field.val(_.UUID.v4());
+            uuid_field.trigger("change");
         });
 
         CloudPebble.Sidebar.SetActivePane(pane, 'settings');

--- a/ide/templates/ide/project.html
+++ b/ide/templates/ide/project.html
@@ -497,6 +497,7 @@ var LIBPEBBLE_PROXY = {{ libpebble_proxy | safe }};
 <script src="{% static 'ide/js/syntax.js' %}" type="text/javascript"></script>
 <script src="{% static 'ide/js/autocomplete.js' %}" type="text/javascript"></script>
 <script src="{% static 'ide/js/fuzzyprompt.js' %}" type="text/javascript"></script>
+<script src="{% static 'ide/js/live_settings_form.js' %}" type="text/javascript"></script>
 <script src="{% static 'ide/js/compile.js' %}" type="text/javascript"></script>
 <script src="{% static 'ide/js/resources.js' %}" type="text/javascript"></script>
 <script src="{% static 'ide/js/settings.js' %}" type="text/javascript"></script>

--- a/ide/templates/ide/project/settings.html
+++ b/ide/templates/ide/project/settings.html
@@ -1,8 +1,8 @@
 {% load i18n %}
 <!-- Settings template -->
 <div id="settings-pane-template" class="hide settings-pane">
+    <div class="well alert alert-error hide fixed-well"></div>
     <form class="form-horizontal">
-        <div class="well alert alert-error hide"></div>
         <div class="well">
             <div class="control-group">
                 <label class="control-label" for="settings-name">{% trans 'Project name' %}</label>
@@ -169,7 +169,6 @@
             </div>
         </div>
         <div class="well form-actions">
-            <button id="project-save" class="btn btn-affirmative">{% trans "Save changes" %}</button>
             <button id="project-export-zip" class="btn">{% trans "Download as zip" %}</button>
             <button id="project-delete" class="btn btn-danger">{% trans "Delete Project" %}</button>
         </div>

--- a/ide/templates/ide/settings.html
+++ b/ide/templates/ide/settings.html
@@ -37,7 +37,6 @@
                 </div>
                 {% endfor %}
                 <div class="form-actions">
-                    <input type="submit" class="btn btn-primary" value="{% trans 'Submit' %}">
                     <input type="reset" class="btn" value="{% trans 'Reset' %}">
                 </div>
             </form>
@@ -80,5 +79,34 @@
         e.preventDefault();
         $('#unlink-form').submit();
     });
+
+    $(function() {
+        var save = function() {
+            var defer = $.Deferred();
+            $.ajax({
+                type: "POST",
+                url: "settings",
+                data: $("#user-settings-form").serialize(), // serializes the form's elements.
+                success: function(data) {
+                    defer.resolve();
+                },
+                error: function(e) {
+                    defer.reject(interpolate(gettext("Error: %s"), [error]));
+                }
+            });
+            return defer.promise();
+        };
+        make_live_settings_form({
+            save_function: save,
+            form: $("#user-settings-form")
+        });
+
+        $("#user-settings-form").submit(function(e) {
+            e.preventDefault();
+            return false;
+        });
+    });
+
 </script>
+<script src="{% static 'ide/js/live_settings_form.js' %}" type="text/javascript"></script>
 {% endblock %}

--- a/root/static/common/css/common.css
+++ b/root/static/common/css/common.css
@@ -650,3 +650,24 @@ select:invalid {
     height: 30px;
     padding-top: 2px;
 }
+
+.settings-status-icons {
+    position: relative;
+    top: 10px;
+    float: right;
+}
+
+.editor-settings .settings-status-icons {
+    left: 10px;
+}
+
+.settings-status-icons span {
+    background-image: url("../../common/img/glyphicons-halflings-white.png");
+}
+
+.fixed-well {
+  position: fixed;
+  width: 300px !important;
+  margin-left: 200px !important;
+  margin-top: -30px !important;
+}


### PR DESCRIPTION
Settings pages now behave in the following way:
- When typing in a text field, a 'changed' icon appears
- When any form element is changed, the whole form is submitted/saved
- Any reset button submits the form immediately
- If the save is successful, all form fields which have changed flash a tick icon
- If the save fails (e.g. validation error), all fields which have changed show a changed icon, indicating that the changes are unsaved. In the project settings page, an error box is shown to describe the problem.

I've made a function which can make any form behave as described above, and applied it to the project and user settings pages.