### PR TITLE
Fixed prompts not showing in fullscreen edit mode.

### DIFF
--- a/ide/static/ide/js/editor.js
+++ b/ide/static/ide/js/editor.js
@@ -3,6 +3,7 @@ CloudPebble.Editor = (function() {
     var open_codemirrors = {};
     var unsaved_files = 0;
     var is_fullscreen = false;
+    var resume_fullscreen = false;
 
     var add_source_file = function(file) {
         CloudPebble.Sidebar.AddSourceFile(file, function() {
@@ -34,6 +35,9 @@ CloudPebble.Editor = (function() {
         if(CloudPebble.Sidebar.Restore('source-'+file.id)) {
             if(callback) {
                 callback(open_codemirrors[file.id]);
+            }
+            if (resume_fullscreen) {
+                fullscreen(open_codemirrors[file.id], true);
             }
             return;
         }
@@ -579,6 +583,12 @@ CloudPebble.Editor = (function() {
                 },function() {
                     $('.fullscreen-icon-tooltip').fadeOut(300);
                 });
+                $('#main-pane').data('pane-suspend-function', function() {
+                    if (is_fullscreen) {
+                        fullscreen(code_mirror, false);
+                        resume_fullscreen = true;
+                    }
+                });
 
                 $(document).keyup(function(e) {
                   if (e.keyCode == 27) { fullscreen(code_mirror, false); }   // Esc exits fullscreen mode
@@ -588,6 +598,9 @@ CloudPebble.Editor = (function() {
                     toggle_ib();
                 }
 
+                if (resume_fullscreen) {
+                    fullscreen(code_mirror, true);
+                }
                 if(callback) {
                     callback(code_mirror);
                 }
@@ -664,6 +677,7 @@ CloudPebble.Editor = (function() {
                 .removeClass('FullScreen')
                 .css({'height' : newHeight})
                 .prependTo(code_mirror.parent_pane);
+            resume_fullscreen = false;
         }
         code_mirror.refresh();
         code_mirror.focus();

--- a/root/static/common/css/common.css
+++ b/root/static/common/css/common.css
@@ -466,7 +466,7 @@ input[type=checkbox]:checked {
     position: fixed;
     top: 10%;
     left: 50%;
-    z-index: 1050;
+    z-index: 10001;
     margin-left: -300px;
     width: 600px;
     background-color: #333;


### PR DESCRIPTION
This fixes the bug identified by @thunsaker in #171, i.e. the cmd-prompt not appearing in full-screen mode. In fact, no prompts would appear in full screen mode, so this fixes that too.

The solution is fairly crude, but effective. When switching to another file, fullscreen is disabled and resume_fullscreen = true. When a new file loads, if (resume_fullscreen == true), fullscreen is re-enabled.

I say crude because it means that you get switched back to the non-fullscreen IDE while a new file loads, but this only happens once per file; the switch to a file which is already open is instantaneous. 