### PR TITLE
Fixed fuzzy prompt not toggling off with cmd-p

### DIFF
--- a/ide/static/ide/js/fuzzyprompt.js
+++ b/ide/static/ide/js/fuzzyprompt.js
@@ -54,6 +54,8 @@ CloudPebble.FuzzyPrompt = (function() {
                 // Ctrl-P to hide
                 if (e[modifier] && e.keyCode == 80) {
                     hide_prompt();
+                    e.preventDefault();
+                    e.stopPropagation();
                 }
                 // Enter to select
                 else if (e.keyCode == 13) {


### PR DESCRIPTION
Cmd-P is supposed to close fuzzy-prompt when it's already open, but the keydown event was bubbling up and opening the prompt again. No longer!