### PR TITLE
Fix for TAB key opening up first code fold.

### DIFF
--- a/ide/static/ide/js/editor.js
+++ b/ide/static/ide/js/editor.js
@@ -89,6 +89,7 @@ CloudPebble.Editor = (function() {
                         var distance = 99999999999; // eh
                         for (var i = marks.length - 1; i >= 0; i--) {
                             var mark = marks[i];
+                            if (mark.className !== "cm-autofilled") continue;
                             var pos = mark.find();
                             if(pos === undefined) continue;
                             if(cursor.line >= pos.from.line - 5) {


### PR DESCRIPTION
The tab-to-autocomplete-arguments thing would select any marks including code folds, so pressing TAB with any code folded would cause problems. Now it only selects marks with className=="cm-autofilled".
