### PR TITLE
Fix for code-fold persistance with pebble.js projects

### DIFF
--- a/ide/static/ide/js/editor.js
+++ b/ide/static/ide/js/editor.js
@@ -361,10 +361,11 @@ CloudPebble.Editor = (function() {
                                 });
                         }
                     });
-                    code_mirror.force_fold_lines(data.folded_lines);
-                    // This is needed to force focus on the editor
-                    setTimeout(function() { code_mirror.focus();}, 1);
                 }
+                
+                code_mirror.force_fold_lines(data.folded_lines);
+                // This is needed to force focus on the editor
+                setTimeout(function() { code_mirror.focus();}, 1);
 
                 function update_patch_list(instance, changes) {
                     _.each(changes, function(change) {


### PR DESCRIPTION
I had accidentally put left the logic for re-folding code inside a conditional which had it only run when editing C files, so it was broken in pebble.js projects. This fixes that issue.