### PR TITLE
PBL-22355 CloudPebble should support targetPlatforms

### DIFF
--- a/ide/api/resource.py
+++ b/ide/api/resource.py
@@ -39,10 +39,9 @@ def create_resource(request, project_id):
                 colour_variant = ResourceVariant.objects.create(resource_file=rf, variant=ResourceVariant.VARIANT_COLOUR)
                 colour_variant.save_file(colour_file, colour_file.size)
 
-            target_platforms = json.loads(request.POST.get('target_platforms', 'null'))
-            if json.loads(rf.target_platforms) != target_platforms:
-                rf.target_platforms = json.dumps(target_platforms)
-                rf.save()
+            target_platforms = json.loads(request.POST.get('target_platforms', None))
+            rf.target_platforms = None if target_platforms is None else json.dumps(target_platforms)
+            rf.save()
 
     except Exception as e:
         return json_failure(str(e))
@@ -59,7 +58,7 @@ def create_resource(request, project_id):
             "id": rf.id,
             "kind": rf.kind,
             "file_name": rf.file_name,
-            "target_platforms": json.loads(rf.target_platforms),
+            "target_platforms": json.loads(rf.target_platforms) if rf.target_platforms else None,
             "resource_ids": [{'id': x.resource_id, 'regex': x.character_regex} for x in resources],
             "identifiers": [x.resource_id for x in resources],
             "variants": [x.variant for x in rf.variants.all()],
@@ -84,7 +83,7 @@ def resource_info(request, project_id, resource_id):
 
     return json_response({
         'resource': {
-            'target_platforms': json.loads(resource.target_platforms),
+            "target_platforms": json.loads(resource.target_platforms) if resource.target_platforms else None,
             'resource_ids': [{
                                  'id': x.resource_id,
                                  'regex': x.character_regex,
@@ -127,7 +126,7 @@ def update_resource(request, project_id, resource_id):
     project = get_object_or_404(Project, pk=project_id, owner=request.user)
     resource = get_object_or_404(ResourceFile, pk=resource_id, project=project)
     resource_ids = json.loads(request.POST['resource_ids'])
-    target_platforms = json.loads(request.POST.get('target_platforms', 'null'))
+    target_platforms = json.loads(request.POST.get('target_platforms', None))
     try:
         with transaction.atomic():
             # Lazy approach: delete all the resource_ids and recreate them.
@@ -146,9 +145,9 @@ def update_resource(request, project_id, resource_id):
             if 'file_colour' in request.FILES:
                 colour_variant = resource.variants.get_or_create(variant=ResourceVariant.VARIANT_COLOUR)[0]
                 colour_variant.save_file(request.FILES['file_colour'], request.FILES['file_colour'].size)
-            if json.loads(resource.target_platforms) != target_platforms:
-                resource.target_platforms = json.dumps(target_platforms)
-                resource.save()
+
+            resource.target_platforms = None if target_platforms is None else json.dumps(target_platforms)
+            resource.save()
     except Exception as e:
         return json_failure(str(e))
     else:
@@ -158,13 +157,12 @@ def update_resource(request, project_id, resource_id):
                 'kind': 'source'
             }
         }, project=project, request=request)
-
         return json_response({"file": {
             "id": resource.id,
             "kind": resource.kind,
             "file_name": resource.file_name,
             "resource_ids": [{'id': x.resource_id, 'regex': x.character_regex, 'compatibility': x.compatibility} for x in resources],
-            "target_platforms": json.loads(resource.target_platforms),
+            "target_platforms": json.loads(resource.target_platforms) if resource.target_platforms else None,
             "identifiers": [x.resource_id for x in resources],
             "variants": [x.variant for x in resource.variants.all()],
             "extra": {y.resource_id: {'regex': y.character_regex, 'tracking': y.tracking, 'compatibility': y.compatibility} for y in resource.identifiers.all()}

--- a/ide/migrations/0035_auto__add_field_resourcefile_target_platforms.py
+++ b/ide/migrations/0035_auto__add_field_resourcefile_target_platforms.py
@@ -1,0 +1,164 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'ResourceFile.target_platforms'
+        db.add_column(u'ide_resourcefile', 'target_platforms',
+                      self.gf('django.db.models.fields.CharField')(default='null', max_length=30),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'ResourceFile.target_platforms'
+        db.delete_column(u'ide_resourcefile', 'target_platforms')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'ide.buildresult': {
+            'Meta': {'object_name': 'BuildResult'},
+            'finished': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'builds'", 'to': "orm['ide.Project']"}),
+            'started': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'state': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'uuid': ('django.db.models.fields.CharField', [], {'default': "'0fb1a42b-8730-4f31-ae3f-f7fb37e71ef6'", 'max_length': '36'})
+        },
+        'ide.buildsize': {
+            'Meta': {'object_name': 'BuildSize'},
+            'binary_size': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'build': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'sizes'", 'to': "orm['ide.BuildResult']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'platform': ('django.db.models.fields.CharField', [], {'max_length': '20'}),
+            'resource_size': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'total_size': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'worker_size': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'})
+        },
+        'ide.project': {
+            'Meta': {'object_name': 'Project'},
+            'app_capabilities': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'app_company_name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'app_is_watchface': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'app_jshint': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'app_keys': ('django.db.models.fields.TextField', [], {'default': "'{}'"}),
+            'app_long_name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'app_platforms': ('django.db.models.fields.TextField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'app_short_name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'app_uuid': ('django.db.models.fields.CharField', [], {'default': "'07882890-a757-4e7d-a61c-46a46d81ee95'", 'max_length': '36', 'null': 'True', 'blank': 'True'}),
+            'app_version_label': ('django.db.models.fields.CharField', [], {'default': "'1.0'", 'max_length': '40', 'null': 'True', 'blank': 'True'}),
+            'github_branch': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'github_hook_build': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'github_hook_uuid': ('django.db.models.fields.CharField', [], {'max_length': '36', 'null': 'True', 'blank': 'True'}),
+            'github_last_commit': ('django.db.models.fields.CharField', [], {'max_length': '40', 'null': 'True', 'blank': 'True'}),
+            'github_last_sync': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'github_repo': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_modified': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'optimisation': ('django.db.models.fields.CharField', [], {'default': "'s'", 'max_length': '1'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']"}),
+            'project_type': ('django.db.models.fields.CharField', [], {'default': "'native'", 'max_length': '10'}),
+            'sdk_version': ('django.db.models.fields.CharField', [], {'default': "'2'", 'max_length': '6'})
+        },
+        'ide.resourcefile': {
+            'Meta': {'unique_together': "(('project', 'file_name'),)", 'object_name': 'ResourceFile'},
+            'file_name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_menu_icon': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'kind': ('django.db.models.fields.CharField', [], {'max_length': '9'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'resources'", 'to': "orm['ide.Project']"}),
+            'target_platforms': ('django.db.models.fields.CharField', [], {'default': "'null'", 'max_length': '30'})
+        },
+        'ide.resourceidentifier': {
+            'Meta': {'unique_together': "(('resource_file', 'resource_id'),)", 'object_name': 'ResourceIdentifier'},
+            'character_regex': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'compatibility': ('django.db.models.fields.CharField', [], {'max_length': '10', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'resource_file': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'identifiers'", 'to': "orm['ide.ResourceFile']"}),
+            'resource_id': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'tracking': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'})
+        },
+        'ide.resourcevariant': {
+            'Meta': {'unique_together': "(('resource_file', 'variant'),)", 'object_name': 'ResourceVariant'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_legacy': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'resource_file': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'variants'", 'to': "orm['ide.ResourceFile']"}),
+            'variant': ('django.db.models.fields.IntegerField', [], {})
+        },
+        'ide.sourcefile': {
+            'Meta': {'unique_together': "(('project', 'file_name'),)", 'object_name': 'SourceFile'},
+            'file_name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'folded_lines': ('django.db.models.fields.TextField', [], {'default': "'[]'"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'null': 'True', 'blank': 'True'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'source_files'", 'to': "orm['ide.Project']"}),
+            'target': ('django.db.models.fields.CharField', [], {'default': "'app'", 'max_length': '10'})
+        },
+        'ide.templateproject': {
+            'Meta': {'object_name': 'TemplateProject', '_ormbases': ['ide.Project']},
+            u'project_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['ide.Project']", 'unique': 'True', 'primary_key': 'True'}),
+            'template_kind': ('django.db.models.fields.IntegerField', [], {'db_index': 'True'})
+        },
+        'ide.usergithub': {
+            'Meta': {'object_name': 'UserGithub'},
+            'avatar': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'nonce': ('django.db.models.fields.CharField', [], {'max_length': '36', 'null': 'True', 'blank': 'True'}),
+            'token': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'github'", 'unique': 'True', 'primary_key': 'True', 'to': u"orm['auth.User']"}),
+            'username': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'})
+        },
+        'ide.usersettings': {
+            'Meta': {'object_name': 'UserSettings'},
+            'accepted_terms': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'autocomplete': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'keybinds': ('django.db.models.fields.CharField', [], {'default': "'default'", 'max_length': '20'}),
+            'tab_width': ('django.db.models.fields.PositiveSmallIntegerField', [], {'default': '2'}),
+            'theme': ('django.db.models.fields.CharField', [], {'default': "'cloudpebble'", 'max_length': '50'}),
+            'use_spaces': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'user': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['auth.User']", 'unique': 'True', 'primary_key': 'True'}),
+            'whats_new': ('django.db.models.fields.PositiveIntegerField', [], {'default': '16'})
+        }
+    }
+
+    complete_apps = ['ide']

--- a/ide/migrations/0035_auto__add_field_resourcefile_target_platforms.py
+++ b/ide/migrations/0035_auto__add_field_resourcefile_target_platforms.py
@@ -10,7 +10,7 @@ class Migration(SchemaMigration):
     def forwards(self, orm):
         # Adding field 'ResourceFile.target_platforms'
         db.add_column(u'ide_resourcefile', 'target_platforms',
-                      self.gf('django.db.models.fields.CharField')(default='null', max_length=30),
+                      self.gf('django.db.models.fields.CharField')(default=None, max_length=30, null=True),
                       keep_default=False)
 
 
@@ -63,7 +63,7 @@ class Migration(SchemaMigration):
             'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'builds'", 'to': "orm['ide.Project']"}),
             'started': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'db_index': 'True', 'blank': 'True'}),
             'state': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
-            'uuid': ('django.db.models.fields.CharField', [], {'default': "'0fb1a42b-8730-4f31-ae3f-f7fb37e71ef6'", 'max_length': '36'})
+            'uuid': ('django.db.models.fields.CharField', [], {'default': "'82c659e5-34fb-4f98-bcb7-037b602bb0df'", 'max_length': '36'})
         },
         'ide.buildsize': {
             'Meta': {'object_name': 'BuildSize'},
@@ -85,7 +85,7 @@ class Migration(SchemaMigration):
             'app_long_name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
             'app_platforms': ('django.db.models.fields.TextField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
             'app_short_name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
-            'app_uuid': ('django.db.models.fields.CharField', [], {'default': "'07882890-a757-4e7d-a61c-46a46d81ee95'", 'max_length': '36', 'null': 'True', 'blank': 'True'}),
+            'app_uuid': ('django.db.models.fields.CharField', [], {'default': "'7af783e2-682a-4f2f-a981-071379ff670d'", 'max_length': '36', 'null': 'True', 'blank': 'True'}),
             'app_version_label': ('django.db.models.fields.CharField', [], {'default': "'1.0'", 'max_length': '40', 'null': 'True', 'blank': 'True'}),
             'github_branch': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
             'github_hook_build': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
@@ -108,7 +108,7 @@ class Migration(SchemaMigration):
             'is_menu_icon': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
             'kind': ('django.db.models.fields.CharField', [], {'max_length': '9'}),
             'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'resources'", 'to': "orm['ide.Project']"}),
-            'target_platforms': ('django.db.models.fields.CharField', [], {'default': "'null'", 'max_length': '30'})
+            'target_platforms': ('django.db.models.fields.CharField', [], {'default': 'None', 'max_length': '30', 'null': 'True'})
         },
         'ide.resourceidentifier': {
             'Meta': {'unique_together': "(('resource_file', 'resource_id'),)", 'object_name': 'ResourceIdentifier'},

--- a/ide/models/files.py
+++ b/ide/models/files.py
@@ -26,6 +26,7 @@ class ResourceFile(IdeModel):
     file_name = models.CharField(max_length=100)
     kind = models.CharField(max_length=9, choices=RESOURCE_KINDS)
     is_menu_icon = models.BooleanField(default=False)
+    target_platforms = models.CharField(max_length=30, default="null")
 
     def get_best_variant(self, variant):
         try:

--- a/ide/models/files.py
+++ b/ide/models/files.py
@@ -27,7 +27,7 @@ class ResourceFile(IdeModel):
     file_name = models.CharField(max_length=100)
     kind = models.CharField(max_length=9, choices=RESOURCE_KINDS)
     is_menu_icon = models.BooleanField(default=False)
-    target_platforms = models.CharField(max_length=30, default="null")
+    target_platforms = models.CharField(max_length=30, null=True, default=None)
 
     def get_best_variant(self, variant):
         try:

--- a/ide/static/ide/js/resources.js
+++ b/ide/static/ide/js/resources.js
@@ -1,4 +1,5 @@
 CloudPebble.Resources = (function() {
+    var POSSIBLE_PLATFORMS = ["aplite", "basalt"];
     var project_resources = {};
     var preview_count = 0;
 
@@ -137,6 +138,13 @@ CloudPebble.Resources = (function() {
             form_data.append("file_colour", colour_file);
         }
         form_data.append("resource_ids", JSON.stringify(resources));
+
+        var do_target_platforms = $('#edit-resource-target-platforms-enabled').is(":checked");
+        var target_platforms = (!do_target_platforms ? null : _.filter(POSSIBLE_PLATFORMS, function(platform) {
+            return $('#edit-resource-target-'+platform).is(":checked");
+        }));
+        form_data.append("target_platforms", JSON.stringify(target_platforms));
+
         disable_controls();
         $.ajax({
             url: url,
@@ -170,6 +178,7 @@ CloudPebble.Resources = (function() {
             var resource = data.resource;
             var pane = prepare_resource_pane();
             var list_entry = $('#sidebar-pane-resource-' + resource.id);
+            var target_platforms_checkbox = pane.find("#edit-resource-target-platforms-enabled");
             if(list_entry) {
                 list_entry.addClass('active');
             }
@@ -179,6 +188,11 @@ CloudPebble.Resources = (function() {
 
             pane.find('#edit-resource-type').change();
             //pane.find('#edit-resource-file').after($("<span class='help-block'>" + gettext("If specified, this file will replace the current file for this resource, regardless of its filename.") + "</span>"));
+            
+            var show_resource_targets = function() {
+                $('#edit-resource-targets').toggle(target_platforms_checkbox.is(":checked"));
+            };
+            target_platforms_checkbox.change(show_resource_targets);
 
             // Generate a preview.
             console.log(resource.variants);
@@ -236,7 +250,16 @@ CloudPebble.Resources = (function() {
                 row.append(preview_holder);
                 group.append(row);
             };
-
+            var has_target_platforms = _.isArray(resource["target_platforms"]);
+            if (has_target_platforms) {
+                console.log("checking", target_platforms_checkbox, true);
+                target_platforms_checkbox.prop('checked', true);
+                _.each(POSSIBLE_PLATFORMS, function(platform) {
+                    console.log("Checking", platform, _.contains(resource["target_platforms"], platform));
+                    $("#edit-resource-target-"+platform).prop('checked', _.contains(resource["target_platforms"], platform));
+                });
+            }
+            show_resource_targets();
 
             if(resource.kind != 'font') {
                 if(resource.resource_ids.length > 0) {

--- a/ide/static/ide/js/resources.js
+++ b/ide/static/ide/js/resources.js
@@ -139,9 +139,9 @@ CloudPebble.Resources = (function() {
         }
         form_data.append("resource_ids", JSON.stringify(resources));
 
-        var do_target_platforms = $('#edit-resource-target-platforms-enabled').is(":checked");
+        var do_target_platforms = form.find('#edit-resource-target-platforms-enabled').is(":checked");
         var target_platforms = (!do_target_platforms ? null : _.filter(POSSIBLE_PLATFORMS, function(platform) {
-            return $('#edit-resource-target-'+platform).is(":checked");
+            return form.find('#edit-resource-target-'+platform).is(":checked");
         }));
         form_data.append("target_platforms", JSON.stringify(target_platforms));
 
@@ -183,7 +183,7 @@ CloudPebble.Resources = (function() {
                 list_entry.addClass('active');
             }
 
-            CloudPebble.Sidebar.SetActivePane(pane, 'resource-' + resource.id);
+            CloudPebble.Sidebar.SetActivePane(pane, 'resource-' + resource.id, _.partial(restore_pane, pane));
             pane.find('#edit-resource-type').val(resource.kind).attr('disabled', 'disabled');
 
             pane.find('#edit-resource-type').change();
@@ -252,10 +252,8 @@ CloudPebble.Resources = (function() {
             };
             var has_target_platforms = _.isArray(resource["target_platforms"]);
             if (has_target_platforms) {
-                console.log("checking", target_platforms_checkbox, true);
                 target_platforms_checkbox.prop('checked', true);
                 _.each(POSSIBLE_PLATFORMS, function(platform) {
-                    console.log("Checking", platform, _.contains(resource["target_platforms"], platform));
                     $("#edit-resource-target-"+platform).prop('checked', _.contains(resource["target_platforms"], platform));
                 });
             }
@@ -331,12 +329,17 @@ CloudPebble.Resources = (function() {
                     update_resource(data);
                 });
             });
-            if(CloudPebble.ProjectInfo.sdk_version == '2') {
-                $('.colour-resource').hide();
-            } else {
-                $('.colour-resource').show();
-            }
+            restore_pane(pane);
         });
+    };
+
+
+    var restore_pane = function(parent) {
+        if (CloudPebble.ProjectInfo.sdk_version == '2') {
+            parent.find('.colour-resource, #resource-targets-section').hide();
+        } else {
+            parent.find('.colour-resource, #resource-targets-section').show();
+        }
     };
 
     var prepare_resource_pane = function() {
@@ -362,11 +365,8 @@ CloudPebble.Resources = (function() {
                 template.find('#add-font-resource').addClass('hide');
             }
         });
-        if(CloudPebble.ProjectInfo.sdk_version == '2') {
-            template.find('.colour-resource').hide();
-        } else {
-            template.find('.colour-resource').show();
-        }
+
+        restore_pane(template);
         return template;
     };
 
@@ -391,7 +391,7 @@ CloudPebble.Resources = (function() {
             });
         });
 
-        CloudPebble.Sidebar.SetActivePane(pane, 'new-resource');
+        CloudPebble.Sidebar.SetActivePane(pane, 'new-resource', _.partial(restore_pane, pane));
     };
 
     var resource_created = function(resource) {

--- a/ide/tasks/archive.py
+++ b/ide/tasks/archive.py
@@ -208,6 +208,8 @@ def do_import_archive(project_id, archive, delete_project=False):
                                 tracking = resource.get('trackingAdjust', None)
                                 is_menu_icon = resource.get('menuIcon', False)
                                 compatibility = resource.get('compatibility', None)
+                                target_platforms = resource.get('targetPlatforms', None)
+                                target_platforms = json.dumps(target_platforms) if target_platforms else None
 
                                 if file_name not in resource_files:
                                     res_path = 'resources'
@@ -223,7 +225,8 @@ def do_import_archive(project_id, archive, delete_project=False):
                                             project=project,
                                             file_name=os.path.basename(root_file_name),
                                             kind=kind,
-                                            is_menu_icon=is_menu_icon)
+                                            is_menu_icon=is_menu_icon,
+                                            target_platforms=target_platforms)
 
                                         ResourceIdentifier.objects.create(
                                             resource_file=resources[root_file_name],

--- a/ide/templates/ide/project/resource.html
+++ b/ide/templates/ide/project/resource.html
@@ -34,7 +34,7 @@
                 </div>
             </div>
         </div>
-        <div class="well">
+        <div class="well" id="resource-targets-section">
             <div class="control-group">
                 <label style="width: 250px" class="control-label" for="edit-resource-target-platforms-enabled">{% trans 'Target specific platforms' %}</label>
                 <input type="checkbox" id="edit-resource-target-platforms-enabled">

--- a/ide/templates/ide/project/resource.html
+++ b/ide/templates/ide/project/resource.html
@@ -32,6 +32,22 @@
             </div>
         </div>
         <div class="well">
+            <div class="control-group">
+                <label style="width: 250px" class="control-label" for="edit-resource-target-platforms-enabled">{% trans 'Target specific platforms' %}</label>
+                <input type="checkbox" id="edit-resource-target-platforms-enabled">
+            </div>
+            <div id="edit-resource-targets">
+                <div class="control-group">
+                    <label class="control-label" for="edit-resource-target-basalt">Basalt</label>
+                    <input type="checkbox" id="edit-resource-target-basalt">
+                </div>
+                <div class="control-group">
+                    <label class="control-label" for="edit-resource-target-basalt">Aplite</label>
+                    <input type="checkbox" id="edit-resource-target-aplite">
+                </div>
+            </div>
+        </div>
+        <div class="well">
             <div class="control-group image-resource-preview variant-0 hide">
                 <label class="control-label">{% trans 'Generic' %}</label>
                 <div class="controls">

--- a/ide/utils/sdk.py
+++ b/ide/utils/sdk.py
@@ -135,11 +135,13 @@ def build(ctx):
     """
     return wscript.replace('{{jshint}}', 'True' if jshint and not for_export else 'False')
 
+
 def generate_wscript_file(project, for_export=False):
     if project.sdk_version == '2':
         return generate_wscript_file_sdk2(project, for_export)
     elif project.sdk_version == '3':
         return generate_wscript_file_sdk3(project, for_export)
+
 
 def generate_jshint_file(project):
     return """
@@ -246,6 +248,7 @@ def generate_v2_manifest_dict(project, resources):
     }
     return manifest
 
+
 def generate_v3_manifest_dict(project, resources):
     # Just extend the v2 one.
     manifest = generate_v2_manifest_dict(project, resources)
@@ -269,6 +272,7 @@ def generate_manifest_dict(project, resources):
     else:
         raise Exception(_("Unknown project type %s") % project.project_type)
 
+
 def generate_resource_map(project, resources):
     return dict_to_pretty_json(generate_resource_dict(project, resources))
 
@@ -279,7 +283,7 @@ def dict_to_pretty_json(d):
 
 def generate_resource_dict(project, resources):
     if project.project_type == 'native':
-        return generate_v2_resource_dict(resources)
+        return generate_native_resource_dict(project, resources)
     elif project.project_type == 'simplyjs':
         return generate_simplyjs_resource_dict()
     elif project.project_type == 'pebblejs':
@@ -288,7 +292,7 @@ def generate_resource_dict(project, resources):
         raise Exception(_("Unknown project type %s") % project.project_type)
 
 
-def generate_v2_resource_dict(resources):
+def generate_native_resource_dict(project, resources):
     resource_map = {'media': []}
 
     for resource in resources:
@@ -306,6 +310,9 @@ def generate_v2_resource_dict(resources):
                 d['menuIcon'] = True
             if resource_id.compatibility is not None:
                 d['compatibility'] = resource_id.compatibility
+            if project.sdk_version == '3' and resource.target_platforms:
+                d['targetPlatforms'] = json.loads(resource.target_platforms)
+
             resource_map['media'].append(d)
     return resource_map
 


### PR DESCRIPTION
With this PR, CloudPebble will 
- Support importing, exporting and compiling projects which use the "targetPlatforms" attribute on individual resources
- Include a UI for enabling/disabling/toggling targetPlatforms for different platforms
- Toggle the targetPlatforms UI and *also* the colour-file uploader depending on whether the project uses SDK 2 or 3, without a page reload.

<img width="731" alt="screen shot 2015-08-05 at 23 04 18" src="https://cloud.githubusercontent.com/assets/141427/9099149/55ecdcca-3bc6-11e5-9ac5-dfe06f466bd3.png">
<img width="723" alt="screen shot 2015-08-05 at 23 04 14" src="https://cloud.githubusercontent.com/assets/141427/9099150/56122aac-3bc6-11e5-95ee-3587a1d6a064.png">

