### PR TITLE
PBL-24272 CloudPebble: Emulator does not work with Vagrant out of the box

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -70,7 +70,7 @@ popd
 
 
 # Enable SDK3 analytics non-interactively
-touch /home/vagrant/ENABLE_ANALYTICS
+touch /home/vagrant/NO_TRACKING
 
 # Fetch autocompletion tools.
 mkdir /ycmd
@@ -144,6 +144,7 @@ console log
 script
     export PATH="$PATH:/home/vagrant/arm-cs-tools/bin:/home/vagrant/sdk2/bin"
     export DEBUG=yes
+    export QEMU_LAUNCH_TIMEOUT=30
     exec /usr/bin/python manage.py runserver 0.0.0.0:8000
 end script
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -34,6 +34,9 @@ easy_install pip
 # CloudPebble python requirements.
 pip install -r /vagrant/requirements.txt
 
+# Force installation of requests 2.7.0
+easy_install requests==2.7.0
+
 # Make sure we have a useful database
 pushd /vagrant
     sudo -u vagrant python manage.py syncdb --noinput
@@ -65,6 +68,10 @@ pushd sdk3
     pip install -r requirements.txt
 popd
 
+
+# Enable SDK3 analytics non-interactively
+touch /home/vagrant/ENABLE_ANALYTICS
+
 # Fetch autocompletion tools.
 mkdir /ycmd
 pushd /ycmd
@@ -89,7 +96,7 @@ pushd /qemu
 popd
 mkdir /pypkjs
 pushd /pypkjs
-    git clone git@github.com:pebble/pypkjs.git .
+    git clone --recursive https://github.com/pebble/pypkjs.git .
     virtualenv .env
     source .env/bin/activate
     pip install -r requirements.txt
@@ -98,9 +105,17 @@ popd
 
 sudo -u vagrant mkdir qemu-controller
 pushd qemu-controller
-    git clone git@github.com:pebble/cloudpebble-qemu-controller.git .
+    git clone https://github.com/pebble/cloudpebble-qemu-controller.git .
     pip install -r requirements.txt
 popd
+
+sudo -u vagrant mkdir qemu-tintin-images
+pushd qemu-tintin-images
+    git clone https://github.com/pebble/qemu-tintin-images.git .
+popd
+
+# Make sure vagrant user can access the images
+chown vagrant -R /home/vagrant/qemu-tintin-images
 
 # Set up CORS on the lighttpd server.
 cat << 'EOF' > /etc/lighttpd/conf-available/20-cors.conf
@@ -202,6 +217,7 @@ script
     export QEMU_BIN=/qemu/arm-softmmu/qemu-system-arm
     export PKJS_BIN=/pypkjs/phonesim.py
     export PKJS_VIRTUALENV=/pypkjs/.env
+    export QEMU_IMAGE_ROOT=/home/vagrant/qemu-tintin-images
     export DEBUG=yes
     export QCON_PORT=8003
     exec /usr/bin/python controller.py

--- a/cloudpebble/settings.py
+++ b/cloudpebble/settings.py
@@ -294,6 +294,7 @@ COMPLETION_CERTS = _environ.get('COMPLETION_CERTS', os.getcwd() + '/completion-c
 
 QEMU_URLS = _environ.get('QEMU_URLS', 'http://192.168.42.42:8003/').split(',')
 QEMU_LAUNCH_AUTH_HEADER = _environ.get('QEMU_LAUNCH_AUTH_HEADER', 'secret')
+QEMU_LAUNCH_TIMEOUT = int(_environ.get('QEMU_LAUNCH_TIMEOUT', 15))
 
 PHONE_SHORTURL = _environ.get('PHONE_SHORTURL', 'cpbl.io')
 

--- a/ide/api/qemu.py
+++ b/ide/api/qemu.py
@@ -58,7 +58,7 @@ def launch_emulator(request):
                                          'oauth': oauth,
                                          'tz_offset': tz_offset},
                                    headers={'Authorization': settings.QEMU_LAUNCH_AUTH_HEADER},
-                                   timeout=30,
+                                   timeout=settings.QEMU_LAUNCH_TIMEOUT,
                                    verify=settings.COMPLETION_CERTS)
             result.raise_for_status()
             response = result.json()

--- a/ide/api/qemu.py
+++ b/ide/api/qemu.py
@@ -58,7 +58,7 @@ def launch_emulator(request):
                                          'oauth': oauth,
                                          'tz_offset': tz_offset},
                                    headers={'Authorization': settings.QEMU_LAUNCH_AUTH_HEADER},
-                                   timeout=15,
+                                   timeout=30,
                                    verify=settings.COMPLETION_CERTS)
             result.raise_for_status()
             response = result.json()

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ redis==2.9.1
 boto==2.27.0
 gevent==1.0.1
 psycogreen==1.0
-requests==2.4.1
+requests==2.7.0
 oauth2client==1.3
 
 # This is used for Mailchimp integration
@@ -34,14 +34,14 @@ virtualenv
 freetype-py==1.0
 sh==1.08
 websocket-client==0.32.0
-pyserial>=2.6
-pypng==0.0.16
-libpebble2>=0.0.7
+pyserial>=2.7
+pypng==0.0.17
+libpebble2>=0.0.8
 enum34==1.0.4
 httplib2==0.9.1
 progressbar2==2.7.3
-pyasn1==0.1.7
-pyasn1-modules==0.0.5
+pyasn1==0.1.8
+pyasn1-modules==0.0.6
 rsa==3.1.4
 six==1.9.0
 wheel==0.24.0


### PR DESCRIPTION
In combination with the following PRs:
https://github.com/pebble/cloudpebble-qemu-controller/pull/2
https://github.com/pebble/pypkjs/pull/12

This PR fixes the emulator in CloudPebble when running in the vagrant box. It consists of the following changes...

... in bootstrap.sh:
- Force installation of requests==2.7.0
- Added ENABLE_ANALYTICS file
- Use HTTP links for git repos
- Added qemu-tintin-images repo, chowned by vagrant
- Recursively clone pypkjs

... in qemu.py:
- Increased the timeout on CloudPebble to accomodate vagrant's slower qemu launch speed

... in requirements.txt:
- Updated cloudpebble requirements.txt to be inline with pebble-tool's (mostly just minor version increases).