### PR TITLE
PBL-24917 log window improvements

### DIFF
--- a/ide/api/__init__.py
+++ b/ide/api/__init__.py
@@ -33,6 +33,8 @@ def proxy_keen(request, project_id):
         'websocket_connection_failed',
         'app_install_failed',
         'app_log_view',
+        'app_log_clear',
+        'app_log_download',
         'app_logged_crash',
         'sdk_screenshot_success',
         'sdk_screenshot_failed',

--- a/ide/static/ide/css/ide.css
+++ b/ide/static/ide/css/ide.css
@@ -258,7 +258,7 @@ ul.nav-pills {
     height: 100% !important;
 }
 
-#editor-button-wrapper {
+.editor-button-wrapper {
     position: absolute;
     width: 40px;
     margin-left: 5px;
@@ -268,7 +268,7 @@ ul.nav-pills {
     bottom: 0;
 }
 
-#editor-button-wrapper .btn {
+.editor-button-wrapper .btn {
     margin-top: 10px;
 }
 
@@ -308,7 +308,7 @@ ul.nav-pills {
     background-color: #e5171f;
 }
 
-#editor-button-wrapper .btn:hover {
+.editor-button-wrapper .btn:hover {
     opacity: 0.8;
 }
 
@@ -1006,5 +1006,18 @@ span.cm-autofilled-end {
 
 .padded-modal-header {
     padding: 10px 25px 10px 10px;
+}
+
+.app-log {
+    position: absolute;
+    left: 0;
+    right: 50px;
+    top: 0;
+    bottom: 0;
+}
+.app-log > .build-log {
+    height: 100%;
+    overflow: auto;
+    margin: 0;
 }
 

--- a/ide/static/ide/js/compile.js
+++ b/ide/static/ide/js/compile.js
@@ -444,6 +444,13 @@ CloudPebble.Compile = (function() {
         return gettext('[VERBOSE]');
     };
 
+    function add_log_divider() {
+        // Only add a log divider if the previous log entry wasn't also a divider.
+        if (mPreviousDisplayLogs.length > 0 && mPreviousDisplayLogs[mPreviousDisplayLogs.length-1] !== null) {
+            mPreviousDisplayLogs.push(null);
+        }
+    }
+
     var install_on_watch = function(kind) {
         var modal = $('#phone-install-progress');
 
@@ -457,7 +464,7 @@ CloudPebble.Compile = (function() {
             pebble.on('status', function(code) {
                 pebble.off('install:progress');
                 if(code === 0) {
-                    mPreviousDisplayLogs.push(null);
+                    add_log_divider();
                     pebble.enable_app_logs();
                     modal.find('.modal-body > p').text(gettext("Installed successfully!"));
                     modal.find('.btn').removeClass('hide');
@@ -643,7 +650,7 @@ CloudPebble.Compile = (function() {
         if(!SharedPebble.isVirtual()) {
             SharedPebble.disconnect();
         }
-        mPreviousDisplayLogs.push(null);
+        add_log_divider();
         mLastScrollTop = (mLogHolder ? (logs_scrolled_to_bottom() ? 'bottom' : mLogHolder[0].scrollTop) : mLastScrollTop);
         mLogHolder = null;
     };

--- a/ide/static/ide/js/compile.js
+++ b/ide/static/ide/js/compile.js
@@ -336,10 +336,11 @@ CloudPebble.Compile = (function() {
     };
 
     function logs_scrolled_to_bottom() {
-        if (mLogHolder == null) {
+        // Return true if the log window is scrolled to within 20 pixels of the bottom.
+        if (!mLogHolder) {
             return false;
         }
-        return (mLogHolder[0].scrollHeight - mLogHolder.scrollTop() == mLogHolder.outerHeight());
+        return (mLogHolder[0].scrollHeight - mLogHolder.scrollTop() <= mLogHolder.outerHeight() + 20);
     }
 
     function scroll_logs_to_bottom() {
@@ -446,7 +447,7 @@ CloudPebble.Compile = (function() {
 
     function add_log_divider() {
         // Only add a log divider if the previous log entry wasn't also a divider.
-        if (mPreviousDisplayLogs.length > 0 && mPreviousDisplayLogs[mPreviousDisplayLogs.length-1] !== null) {
+        if (_.last(mPreviousDisplayLogs)) {
             mPreviousDisplayLogs.push(null);
         }
     }
@@ -580,7 +581,7 @@ CloudPebble.Compile = (function() {
                     .attr('target', '_blank')
                     .appendTo(buttonHolder)
                     .click(function() {
-                        this.href = "data:text/plain;base64,"+window.btoa(mLogHolder.text());
+                        this.href = "data:text/plain;base64,"+btoa(mLogHolder.text());
                         CloudPebble.Analytics.addEvent('app_log_download', {log_length: mPreviousDisplayLogs.length, virtual: SharedPebble.isVirtual()});
                     });
             } else {

--- a/ide/static/ide/js/compile.js
+++ b/ide/static/ide/js/compile.js
@@ -538,8 +538,17 @@ CloudPebble.Compile = (function() {
                 var buttonHolder = $("<div>").addClass("editor-button-wrapper").appendTo(parentPane);
                 $("<button>")
                     .addClass('btn delete-btn')
-                    .attr('title', "Clear Logs")
+                    .attr('title', gettext("Clear Logs"))
                     .appendTo(buttonHolder).click(show_clear_logs_prompt);
+                $("<a>")
+                    .addClass('btn save-btn')
+                    .attr('title', gettext("Download Logs"))
+                    .attr('download', "CloudPebble.log")
+                    .attr('target', '_blank')
+                    .appendTo(buttonHolder)
+                    .click(function() {
+                        this.href = "data:text/plain;base64,"+window.btoa(mLogHolder.text());
+                    });
             } else {
                 mLogHolder.empty();
             }

--- a/ide/static/ide/js/compile.js
+++ b/ide/static/ide/js/compile.js
@@ -60,9 +60,8 @@ CloudPebble.Compile = (function() {
             log = log.replace(/^(JavaScript linting failed.*)$/gm, '<span class="log-note">$1</span>');
             // Link the thingies.
             log = log.replace(/([\/a-zA-Z0-9_]+\.[ch]):([0-9+]+)/g, '<span class="filename-link" data-filename="$1" data-line="$2">$1:$2</span>');
-            log = '<pre class="build-log" style="height: 100%;">' + log + '</pre>';
-            var browserHeight = document.documentElement.clientHeight;
-            log = $(log).css({'height': (browserHeight - 130) + 'px', 'overflow': 'auto'});
+            log = '<pre class="build-log">' + log + '</pre>';
+            log = $(log).css({'height': '100%', 'overflow': 'auto'});
             // Make the links do something.
             log.find('.filename-link').click(function() {
                 var thing = $(this);
@@ -163,6 +162,7 @@ CloudPebble.Compile = (function() {
         commands[gettext("Show Emulator Logs")] = function() { show_app_logs(ConnectionType.Qemu); };
         commands[gettext("Show Last Build Log")] = function() {show_build_log(mLastBuild.id)};
         commands[gettext("Compilation")] = function() { show_compile_pane(); ;};
+        commands[gettext("Clear App Logs")] = function() { show_clear_logs_prompt(); };
         CloudPebble.FuzzyPrompt.AddCommands(commands);
 
         SharedPebble.on('app_log', handle_app_log);
@@ -317,7 +317,7 @@ CloudPebble.Compile = (function() {
             } else {
                 var display = _.escape(get_log_label(log.priority) + ' ' + log.filename + ':' + log.line_number + ': ' + log.message);
                 display = display.replace(/([\/a-zA-Z0-9_]+\.[ch]):([0-9+]+)/, '<span class="filename-link" data-filename="$1" data-line="$2">$1:$2</span>');
-                var span = $('<span>').addClass(get_log_class(log.priority)).html(display);
+                var span = $('<span>').addClass(get_log_class(log.priority)).addClass('log').html(display);
                 span.find('.filename-link').click(function() {
                     var thing = $(this);
                     var filename = thing.data('filename');
@@ -336,7 +336,7 @@ CloudPebble.Compile = (function() {
     };
 
     var append_log_html = function(html) {
-        mLogHolder.append(html).append("\n");
+        mLogHolder.append(html.append("\n"));
         mLogHolder[0].scrollTop = mLogHolder[0].scrollHeight;
     };
 
@@ -516,6 +516,14 @@ CloudPebble.Compile = (function() {
         });
     };
 
+    var show_clear_logs_prompt = function() {
+        CloudPebble.Prompts.Confirm(gettext("Clear all app logs?"), gettext("This cannot be undone."), function() {
+            mLogHolder.empty();
+            mPreviousDisplayLogs = [];
+            ga('send', 'event', 'logs', 'delete');
+        });
+    };
+
     var show_app_logs = function(kind) {
         SharedPebble.getPebble(kind).done(function(pebble) {
             pebble.on('close', function() {
@@ -524,13 +532,19 @@ CloudPebble.Compile = (function() {
             });
             CloudPebble.Sidebar.SuspendActive();
             if(!mLogHolder) {
-                var browserHeight = document.documentElement.clientHeight;
-                mLogHolder = $('<pre class="build-log">').css({'height': (browserHeight - 130) + 'px', 'overflow': 'auto'});
+                var parentPane = $('<div></div>');
+                var logPane = $('<div></div>').addClass("app-log").appendTo(parentPane);
+                mLogHolder = $('<pre class="build-log">').appendTo(logPane);
+                var buttonHolder = $("<div>").addClass("editor-button-wrapper").appendTo(parentPane);
+                $("<button>")
+                    .addClass('btn delete-btn')
+                    .attr('title', "Clear Logs")
+                    .appendTo(buttonHolder).click(show_clear_logs_prompt);
             } else {
                 mLogHolder.empty();
             }
             _.each(mPreviousDisplayLogs, _.partial(show_log_line, _, true));
-            CloudPebble.Sidebar.SetActivePane(mLogHolder, undefined, undefined, stop_logs);
+            CloudPebble.Sidebar.SetActivePane(parentPane, undefined, undefined, stop_logs);
             CloudPebble.Analytics.addEvent('app_log_view', {virtual: SharedPebble.isVirtual()});
         });
     };

--- a/ide/static/ide/js/compile.js
+++ b/ide/static/ide/js/compile.js
@@ -9,7 +9,7 @@ CloudPebble.Compile = (function() {
 
     var mPendingCallbacks = [];
     var mRunningBuild = false;
-
+    var mLastScrollTop = 'bottom';
     var mLastBuild = null;
 
     var build_history_row = function(build) {
@@ -335,9 +335,34 @@ CloudPebble.Compile = (function() {
         }
     };
 
+    function logs_scrolled_to_bottom() {
+        if (mLogHolder == null) {
+            return false;
+        }
+        return (mLogHolder[0].scrollHeight - mLogHolder.scrollTop() == mLogHolder.outerHeight());
+    }
+
+    function scroll_logs_to_bottom() {
+        mLogHolder[0].scrollTop = mLogHolder[0].scrollHeight - mLogHolder.outerHeight();
+    }
+
+    function restore_scroll_position() {
+        if (mLastScrollTop == 'bottom') {
+            scroll_logs_to_bottom();
+        }
+        else if (_.isNumber(mLastScrollTop)) {
+            mLogHolder[0].scrollTop = mLastScrollTop;
+        }
+    }
+
     var append_log_html = function(html) {
+        // Append the HTML line to the log
+        var at_bottom = logs_scrolled_to_bottom();
         mLogHolder.append(html.append("\n"));
-        mLogHolder[0].scrollTop = mLogHolder[0].scrollHeight;
+        // Then, scroll to the bottom if we were already scrolled to the bottom before.
+        if (at_bottom) {
+            mLogHolder[0].scrollTop = mLogHolder[0].scrollHeight - mLogHolder.outerHeight();
+        }
     };
 
     var handle_crash = function(process, is_our_crash, pc, lr) {
@@ -555,6 +580,7 @@ CloudPebble.Compile = (function() {
             _.each(mPreviousDisplayLogs, _.partial(show_log_line, _, true));
             CloudPebble.Sidebar.SetActivePane(parentPane, undefined, undefined, stop_logs);
             CloudPebble.Analytics.addEvent('app_log_view', {virtual: SharedPebble.isVirtual()});
+            restore_scroll_position();
         });
     };
 
@@ -618,6 +644,7 @@ CloudPebble.Compile = (function() {
             SharedPebble.disconnect();
         }
         mPreviousDisplayLogs.push(null);
+        mLastScrollTop = (mLogHolder ? (logs_scrolled_to_bottom() ? 'bottom' : mLogHolder[0].scrollTop) : mLastScrollTop);
         mLogHolder = null;
     };
 

--- a/ide/static/ide/js/compile.js
+++ b/ide/static/ide/js/compile.js
@@ -550,9 +550,10 @@ CloudPebble.Compile = (function() {
 
     var show_clear_logs_prompt = function() {
         CloudPebble.Prompts.Confirm(gettext("Clear all app logs?"), gettext("This cannot be undone."), function() {
+            ga('send', 'event', 'logs', 'delete');
+            CloudPebble.Analytics.addEvent('app_log_clear', {log_length: mPreviousDisplayLogs.length, virtual: SharedPebble.isVirtual()});
             mLogHolder.empty();
             mPreviousDisplayLogs = [];
-            ga('send', 'event', 'logs', 'delete');
         });
     };
 
@@ -580,6 +581,7 @@ CloudPebble.Compile = (function() {
                     .appendTo(buttonHolder)
                     .click(function() {
                         this.href = "data:text/plain;base64,"+window.btoa(mLogHolder.text());
+                        CloudPebble.Analytics.addEvent('app_log_download', {log_length: mPreviousDisplayLogs.length, virtual: SharedPebble.isVirtual()});
                     });
             } else {
                 mLogHolder.empty();

--- a/ide/static/ide/js/editor.js
+++ b/ide/static/ide/js/editor.js
@@ -581,7 +581,7 @@ CloudPebble.Editor = (function() {
                 });
 
                 // Add some buttons
-                var button_holder = $('<p id="editor-button-wrapper">');
+                var button_holder = $('<p class="editor-button-wrapper">');
                 var run_btn = $('<button class="btn run-btn" title="' + gettext("Save, build, install and run") + '"></button>');
                 var save_btn = $('<button class="btn save-btn" title="' + gettext('Save') + '"></button>');
                 var discard_btn = $('<button class="btn reload-btn" title="' + gettext('Reload') + '"></button>');


### PR DESCRIPTION
Instead of #175, this PR makes a number of small changes to the logs window on a cleaned up branch:
* PBL-24918 improve scrolling behavior: the log window now remembers its scroll position, and only sticks to the bottom 
* PBL-24918 fix spurious HRs: < hr >s were added to the logs when switching back to the log window. Now they are only added if the last log wasn't also a < hr >, to prevent a clutter of < hr >s when switching back and forth. 
* PBL-24918 deleting and saving logs: 'Delete logs' and 'Download logs' buttons have been added. ( #100 #187 )