### PR TITLE
PBL-25232 Cannot git-pull when a resource only has tagged variants

### DIFF
--- a/ide/tasks/git.py
+++ b/ide/tasks/git.py
@@ -207,8 +207,8 @@ def github_push(user, commit_message, repo_name, project):
     return False
 
 def get_root_path(path):
-    split_path = os.path.splitext(path)
-    return split_path[0].split('~', 1)[0] + split_path[1]
+    path, extension = os.path.splitext(path)
+    return path.split('~', 1)[0] + extension
 
 @git_auth_check
 def github_pull(user, project):


### PR DESCRIPTION
This fixes a bug in the github pull API command which prevented it from pulling from projects where one of the resources has no generic/default variant, by updating the "list of existing resources" to not include tags in the file names.