### PR TITLE
PBL-24916 Spurious automatic tabs when typing

### DIFF
--- a/ide/static/ide/js/syntax.js
+++ b/ide/static/ide/js/syntax.js
@@ -1,5 +1,5 @@
 CloudPebble.Editor.PebbleMode = {
-    name: 'clike',
+    name: 'text/x-c',
     useCPP: true,
     keywords: {
         // C


### PR DESCRIPTION
The CloudPebble source editor didn't recognize preprocessor instructions, so pressing Enter on any line which was preceeded by a preprocessor instruction would also insert a tab. 

This is easily fixed by extending codemirror's 'text/x-c' instead of 'clike'.