### PR TITLE
Fix for hidden help dialog

### DIFF
--- a/ide/static/ide/css/ide.css
+++ b/ide/static/ide/css/ide.css
@@ -964,7 +964,7 @@ span.cm-autofilled-end {
 }
 
 #help-prompt-holder {
-    z-index: 2000;
+    z-index: 10001;
     position: relative;
 }
 


### PR DESCRIPTION
This change fixes this:
![screenshot of problem](https://s3.amazonaws.com/uploads.hipchat.com/88982/995556/Tog0vmgEhLRw6w5/Screen%20Shot%202015-09-23%20at%2011.15.52.png)