### PR TITLE
PBL-25403 Cmd/Ctrl-S in CloudPebble only works in code editors

### DIFF
--- a/ide/static/ide/js/cloudpebble.js
+++ b/ide/static/ide/js/cloudpebble.js
@@ -182,3 +182,46 @@ CloudPebble.Utils = {
         return interpolate(ngettext("%s second", "%s seconds", n), [n]);
     }
 };
+
+CloudPebble.GlobalShortcuts = (function() {
+    var make_shortcut_checker = function (command) {
+        if (!(command.indexOf('-') > -1)) {
+            command = _.findKey(CodeMirror.keyMap.default, _.partial(_.isEqual, command));
+        }
+        var split = command.split('-');
+        var modifier = ({
+            'ctrl': 'ctrlKey',
+            'cmd': 'metaKey'
+        })[split[0].toLowerCase()];
+        return function (e) {
+            return (e[modifier] && String.fromCharCode(e.keyCode) == split[1]);
+        }
+    };
+
+
+    var global_shortcuts = {};
+
+    $(document).keydown(function (e) {
+        if (!e.isDefaultPrevented()) {
+            _.each(global_shortcuts, function (shortcut) {
+                if (shortcut.checker(e)) {
+                    shortcut.func(e);
+                    e.preventDefault();
+                }
+            });
+        }
+    });
+
+    return {
+        SetShortcutHandlers: function (shortcuts) {
+            var new_shortcuts = _.mapObject(shortcuts, function (func, key) {
+                return {
+                    checker: make_shortcut_checker(key),
+                    func: func
+                };
+
+            });
+            _.extend(global_shortcuts, new_shortcuts);
+        }
+    }
+})();

--- a/ide/static/ide/js/editor.js
+++ b/ide/static/ide/js/editor.js
@@ -452,8 +452,8 @@ CloudPebble.Editor = (function() {
                         } else {
                             alert(data.error);
                         }
-                        if(callback) {
-                            callback()
+                        if(_.isFunction(callback)) {
+                            callback();
                         }
                     });
                 };
@@ -528,6 +528,10 @@ CloudPebble.Editor = (function() {
                 var ib_pane = $('#ui-editor-pane-template').clone().removeClass('hide').appendTo(pane).hide();
                 var ib_editor = new IB(ib_pane.find('.ui-canvas'), ib_pane.find('#ui-properties'), ib_pane.find('#ui-toolkit'), ib_pane.find('#ui-layer-list > div'));
                 var ib_showing = false;
+
+                CloudPebble.GlobalShortcuts.SetShortcutHandlers({
+                    save: save
+                });
 
                 function toggle_ib() {
                     if(!ib_showing) {

--- a/ide/static/ide/js/resources.js
+++ b/ide/static/ide/js/resources.js
@@ -322,7 +322,7 @@ CloudPebble.Resources = (function() {
             });
 
             var form = pane.find('form');
-            form.submit(function(e) {
+            var save = function(e) {
                 e.preventDefault();
                 process_resource_form(form, false, resource.file_name, "/ide/project/" + PROJECT_ID + "/resource/" + resource.id + "/update", function(data) {
                     // Update any previews we have.
@@ -356,6 +356,10 @@ CloudPebble.Resources = (function() {
                     delete project_resources[resource.file_name];
                     update_resource(data);
                 });
+            };
+            form.submit(save);
+            CloudPebble.GlobalShortcuts.SetShortcutHandlers({
+                save: save
             });
             restore_pane(pane);
         });

--- a/root/templates/common/base.html
+++ b/root/templates/common/base.html
@@ -21,7 +21,7 @@
         </div>
         <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/2.0.3/jquery.min.js"></script>
         <script src="{% static 'common/js/modal.js' %}"></script>
-        <script src="//cdnjs.cloudflare.com/ajax/libs/underscore.js/1.6.0/underscore-min.js"></script>
+        <script src="//cdnjs.cloudflare.com/ajax/libs/underscore.js/1.8.3/underscore-min.js"></script>
         <script src="//cdnjs.cloudflare.com/ajax/libs/backbone.js/1.1.0/backbone-min.js"></script>
         <script src="{% static 'ide/js/whats_new.js' %}"></script>
         <script>


### PR DESCRIPTION
This adds support for global keyboard shortcuts to CloudPebble. 

Panes can call 
```CloudPebble.GlobalShortcuts.SetShortcutHandlers({command_names: function});```
to set what a particular command should do, and command names can be names used by the CodeMirror editor (e.g. 'save') or (a subset of) CodeMirror style shortcut definitions (e.g. "ctrl-C").

Currently this is just used to support keyboard-based saving in the resources and IB panes (as per PBL-25403), but it could be expanded.