### PR TITLE
Set Pillow==2.9.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ flup==1.0.3.dev-20110405
 psycopg2==2.4.5
 South==0.8.4
 qrcode==4.0.4
-Pillow
+Pillow==2.9.0
 pygithub==1.14.2
 python-social-auth==0.1.23
 keen==0.2.3


### PR DESCRIPTION
Pillow version 3.0.x (the current version on from pip) doesn't seem to build/install correctly on our vagrant box, so we need to stick it at 2.9.0.