### PR TITLE
Fix pebblejs support in new release

### DIFF
--- a/ide/static/ide/js/resources.js
+++ b/ide/static/ide/js/resources.js
@@ -26,6 +26,10 @@ CloudPebble.Resources = (function() {
         chalk: [TAG_CHALK, TAG_COLOUR, TAG_ROUND]
     };
 
+    if (CloudPebble.ProjectInfo.type != 'native') {
+        delete PLATFORMS['chalk'];
+    }
+
     /**
      * Get the tag data (from TAGS) for the tag with a specific human-readable name
      * @param {string} name
@@ -695,7 +699,6 @@ CloudPebble.Resources = (function() {
         }
         if(CloudPebble.ProjectInfo.type != 'native') {
             parent.find('.native-only').hide();
-            parent.find('#edit-resource-new-file').hide();
         }
     };
 

--- a/ide/tasks/archive.py
+++ b/ide/tasks/archive.py
@@ -200,7 +200,7 @@ def do_import_archive(project_id, archive, delete_project=False):
                                 identifier = resource['name']
                                 # Pebble.js and simply.js both have some internal resources that we don't import.
                                 if project.project_type in {'pebblejs', 'simplyjs'}:
-                                    if identifier in {'MONO_FONT_14', 'IMAGE_MENU_ICON', 'IMAGE_LOGO_SPLASH', 'IMAGE_TITLE_SPLASH'}:
+                                    if identifier in {'MONO_FONT_14', 'IMAGE_MENU_ICON', 'IMAGE_LOGO_SPLASH', 'IMAGE_TILE_SPLASH'}:
                                         continue
                                 tags, root_file_name = get_filename_variant(file_name, tag_map)
                                 if (len(tags) != 0):

--- a/ide/templates/ide/project/resource.html
+++ b/ide/templates/ide/project/resource.html
@@ -21,7 +21,7 @@
                 </div>
             </div>
 
-            <div class="control-group native-only" id="non-font-resource-group">
+            <div class="control-group" id="non-font-resource-group">
                 <label class="control-label">{% trans 'Identifier' %}</label>
                 <div class="controls">
                     <input type="text" class="edit-resource-id" placeholder="IMAGE_EXAMPLE_IDENTIFIER" pattern="[A-Za-z0-9_]+">
@@ -35,7 +35,7 @@
                 </div>
             </div>
 
-            <div id="resource-targets-section" class="sdk3-only native-only">
+            <div id="resource-targets-section" class="sdk3-only">
                 <div class="control-group">
                     <label style="width: 250px" class="control-label" for="edit-resource-target-platforms-enabled">{% trans 'Target specific platforms' %}</label>
                     <input type="checkbox" id="edit-resource-target-platforms-enabled">
@@ -55,7 +55,7 @@
 
         </div>
 
-        <div class="well image-platform-preview hide sdk3-only native-only">
+        <div class="well image-platform-preview hide sdk3-only">
             <h4>{% trans 'Preview per platform' %}</h4>
             <div class="pane-boxes pane-3-boxes ">
                 {% for platform in supported_platforms %}
@@ -84,14 +84,14 @@
                         <img src=""><p class="image-resource-preview-dimensions">52x52</p>
                     </div>
                 </div>
-                <div class="tag-edit control-group sdk3-only native-only">
+                <div class="tag-edit control-group sdk3-only">
                 {# TODO: support for/id #}
                     <label class="control-label">Tags</label>
                     <div class="controls">
                         <textarea class="resource-tags" rows="1" cols="60"></textarea>
                     </div>
                 </div>
-                <div class="variant-platform-preview control-group sdk3-only native-only">
+                <div class="variant-platform-preview control-group sdk3-only">
                     <label class="control-label">Final platforms</label>
                     <div class="controls label-list"></div>
                 </div>
@@ -111,14 +111,14 @@
                     </div>
                 </div>
 
-                <div class="tag-edit control-group sdk3-only native-only">
+                <div class="tag-edit control-group sdk3-only">
                 {# TODO: support for/id #}
                     <label class="control-label">Tags</label>
                     <div class="controls">
                         <textarea class="resource-tags" rows="1" cols="60"></textarea>
                     </div>
                 </div>
-                <div class="variant-platform-preview control-group sdk3-only native-only">
+                <div class="variant-platform-preview control-group sdk3-only">
                     <label class="control-label">{% trans 'Final platforms' %}</label>
                     <div class="controls label-list"></div>
                 </div>
@@ -172,13 +172,13 @@
                     <input type="file" id="edit-resource-file">
                 </div>
             </div>
-            <div class="tag-edit control-group sdk3-only native-only">
+            <div class="tag-edit control-group sdk3-only">
                 <label class="control-label">Tags</label>
                 <div class="controls">
                     <textarea id="new-resource-tags" class="resource-tags" rows="1" cols="60"></textarea>
                 </div>
             </div>
-            <div class="variant-platform-preview control-group sdk3-only native-only">
+            <div class="variant-platform-preview control-group sdk3-only">
                 <label class="control-label">Final platforms</label>
                 <div class="controls label-list"></div>
             </div>

--- a/ide/views/project.py
+++ b/ide/views/project.py
@@ -32,6 +32,10 @@ def view_project(request, project_id):
         project.app_version_label = '1.0'
     send_keen_event('cloudpebble', 'cloudpebble_open_project', request=request, project=project)
     app_keys = sorted(json.loads(project.app_keys).iteritems(), key=lambda x: x[1])
+    supported_platforms = ["aplite", "basalt"]
+    if project.project_type != 'pebblejs' and project.sdk_version != '2':
+        supported_platforms.append("chalk")
+
     try:
         token = request.user.social_auth.get(provider='pebble').extra_data['access_token']
     except:
@@ -43,7 +47,7 @@ def view_project(request, project_id):
         'libpebble_proxy': json.dumps(settings.LIBPEBBLE_PROXY),
         'token': token,
         'phone_shorturl': settings.PHONE_SHORTURL,
-        'supported_platforms': ["aplite", "basalt", "chalk"]
+        'supported_platforms': supported_platforms
     })
 
 


### PR DESCRIPTION
This fixes problems with pebblejs support caused by the new release. Specifically:
* pebblejs projects can now be imported again
* the resources interface no longer hides most of itself, and also does not show previews for chalk (which is unsupported by pebblejs right now).
