### PR TITLE
Don't hide file upload for sdk2

### DIFF
--- a/ide/static/ide/js/resources.js
+++ b/ide/static/ide/js/resources.js
@@ -514,7 +514,9 @@ CloudPebble.Resources = (function() {
                         });
                     });
                 });
-
+                if (CloudPebble.ProjectInfo.sdk_version == '2' && resource.variants.length > 0) {
+                    pane.find('#edit-resource-new-file').hide();
+                }
                 // Only show the delete-variant buttons if there's more than one variant
                 pane.find('.btn-delvariant').toggle(resource.variants.length > 1);
             };
@@ -691,7 +693,6 @@ CloudPebble.Resources = (function() {
         }
         if(CloudPebble.ProjectInfo.sdk_version != '3') {
             parent.find('.sdk3-only').hide();
-            parent.find('#edit-resource-new-file').hide();
         }
         if(CloudPebble.ProjectInfo.type != 'native') {
             parent.find('.native-only').hide();


### PR DESCRIPTION
Fixed a regression from the move to Round in which the upload file button was hidden for SDK2 projects.
Also added logic to hide said button when after a single file is uploaded for a resource in SDK2 projects.