### PR TITLE
PBL-27831 Add back file replacement capability for resources

### DIFF
--- a/ide/api/resource.py
+++ b/ide/api/resource.py
@@ -157,7 +157,8 @@ def update_resource(request, project_id, resource_id):
     target_platforms = json.loads(request.POST.get('target_platforms', None))
     variant_tags = json.loads(request.POST.get('variants', "[]"))
     new_tags = json.loads(request.POST.get('new_tags', "[]"))
-
+    replacement_map = json.loads(request.POST.get('replacements', "[]"))
+    replacement_files = request.FILES.getlist('replacement_files[]')
     try:
         with transaction.atomic():
             # Lazy approach: delete all the resource_ids and recreate them.
@@ -183,6 +184,12 @@ def update_resource(request, project_id, resource_id):
             if 'file' in request.FILES:
                 variant = resource.variants.create(tags=",".join(str(int(t)) for t in new_tags))
                 variant.save_file(request.FILES['file'], request.FILES['file'].size)
+
+            # We may get sent a list of pairs telling us which variant gets which replacement file
+            for tags, file_index in replacement_map:
+                variant = resource.variants.get(tags=tags)
+                replacement = replacement_files[int(file_index)]
+                variant.save_file(replacement, replacement.size)
 
             resource.target_platforms = None if target_platforms is None else json.dumps(target_platforms)
             if file_name and resource.file_name != file_name:

--- a/ide/static/ide/js/resources.js
+++ b/ide/static/ide/js/resources.js
@@ -383,14 +383,24 @@ CloudPebble.Resources = (function() {
 
         var replacements_files = [];
         var replacement_map = [];
+        var okay = true;
         $.each(form.find('.edit-resource-replace-file'), function() {
-            var file = process_file(kind, this);
+            var file;
+            try {
+                file = process_file(kind, this);
+            }
+            catch (e) {
+                report_error(e);
+                okay = false;
+                return;
+            }
             if (file !== null) {
                 var tags = $(this).parents('.image-resource-preview-pane').find('.text-wrap input').val().slice(1, -1);
                 replacement_map.push([tags, replacements_files.length]);
                 replacements_files.push(file);
             }
         });
+        if (!okay) return;
 
         var form_data = new FormData();
 

--- a/ide/templates/ide/project/resource.html
+++ b/ide/templates/ide/project/resource.html
@@ -95,7 +95,12 @@
                     <label class="control-label">Final platforms</label>
                     <div class="controls label-list"></div>
                 </div>
-
+                <div class="control-group">
+                    <label class="control-label">Replace file</label>
+                    <div class="controls">
+                        <input type="file" class="edit-resource-replace-file">
+                    </div>
+                </div>
                 <button type="button" class="btn btn-small btn-danger btn-delvariant">{% trans 'Delete Variant' %}</button>
             </div>
         </div>

--- a/ide/templates/ide/project/resource.html
+++ b/ide/templates/ide/project/resource.html
@@ -96,7 +96,7 @@
                     <div class="controls label-list"></div>
                 </div>
                 <div class="control-group">
-                    <label class="control-label">Replace file</label>
+                    <label class="control-label">{% trans 'Replace file' %}</label>
                     <div class="controls">
                         <input type="file" class="edit-resource-replace-file">
                     </div>


### PR DESCRIPTION
<img width="699" alt="screen shot 2015-10-20 at 13 03 58" src="https://cloud.githubusercontent.com/assets/141427/10619538/0fbd8aa6-772b-11e5-9abe-ac5b7dd954a1.png">
The "replace file" button replaces resource variant files with newly selected files when the resources form is saved.