### PR TITLE
Fix tag editor CSS

### DIFF
--- a/ide/static/ide/css/ide.css
+++ b/ide/static/ide/css/ide.css
@@ -1213,3 +1213,51 @@ button#add-filter {
     overflow: auto;
     margin: 0;
 }
+
+/** jquery-textext adjustments **/
+
+/* textext-core */
+.text-core .text-wrap {
+    -webkit-border-radius: 10px;
+    -moz-border-radius: 10px;
+    border-radius: 10px;
+}
+
+.text-core .text-wrap textarea,
+.text-core .text-wrap input {
+    line-height: 30px;
+    font-size: large;
+    border: none;
+}
+
+
+/* textext - arrow */
+.text-core .text-wrap .text-arrow {
+    top: 8px;
+    right: 5px;
+    z-index: 3;
+}
+/* textext - autocomplete */
+.text-core .text-wrap .text-dropdown {
+    border: none;
+    font-size: large;
+}
+
+/* textext - prompt */
+.text-core .text-wrap .text-prompt {
+    font-size: large;
+    line-height: 30px;
+}
+
+/* textext - tags */
+.text-core .text-wrap .text-tags .text-tag .text-button {
+    -webkit-border-radius: 7px;
+    -moz-border-radius: 7px;
+    border-radius: 7px;
+    height: 100%;
+    font-size: large;
+}
+
+.text-core .text-wrap .text-tags .text-tag .text-button .text-label {
+  line-height: 30px;
+}


### PR DESCRIPTION
This PR adds back the CSS modifications which were removed in the switch to Bower, returning the tag editor to its previous look.