### PR TITLE
Prevent form submission in CloudPebble text prompt

### DIFF
--- a/ide/static/ide/js/cloudpebble.js
+++ b/ide/static/ide/js/cloudpebble.js
@@ -91,6 +91,7 @@ CloudPebble.Prompts = {
         $('#modal-text-input').modal();
         $('#modal-text-input-value').focus();
         var submit = function(event) {
+            event.preventDefault();
             callback($('#modal-text-input-value').val(), {
                 error: function(message) {
                     $('#modal-text-input-value').removeAttr('disabled');
@@ -107,7 +108,6 @@ CloudPebble.Prompts = {
                     $('#modal-text-input').modal('hide');
                 }
             });
-            event.preventDefault();
         };
         $('#modal-text-confirm-button').unbind('click').click(submit);
         $('#modal-text-input form').unbind('submit').submit(submit);

--- a/ide/static/ide/js/cloudpebble.js
+++ b/ide/static/ide/js/cloudpebble.js
@@ -91,7 +91,7 @@ CloudPebble.Prompts = {
         $('#modal-text-input').modal();
         $('#modal-text-input-value').focus();
         var submit = function() {
-            callback($('#modal-text-input-value').val(), {
+            callback($('#modal-text-input-value').val(event), {
                 error: function(message) {
                     $('#modal-text-input-value').removeAttr('disabled');
                     $('#modal-text-input-confirm-button').removeClass('disabled');
@@ -107,6 +107,7 @@ CloudPebble.Prompts = {
                     $('#modal-text-input').modal('hide');
                 }
             });
+            event.preventDefault();
         };
         $('#modal-text-confirm-button').unbind('click').click(submit);
         $('#modal-text-input form').unbind('submit').submit(submit);

--- a/ide/static/ide/js/cloudpebble.js
+++ b/ide/static/ide/js/cloudpebble.js
@@ -90,8 +90,8 @@ CloudPebble.Prompts = {
         $('#modal-text-input-errors').html('');
         $('#modal-text-input').modal();
         $('#modal-text-input-value').focus();
-        var submit = function() {
-            callback($('#modal-text-input-value').val(event), {
+        var submit = function(event) {
+            callback($('#modal-text-input-value').val(), {
                 error: function(message) {
                     $('#modal-text-input-value').removeAttr('disabled');
                     $('#modal-text-input-confirm-button').removeClass('disabled');


### PR DESCRIPTION
At the moment, if you open a dialog box which uses CloudPebble.Prompts.Prompt (e.g. file rename), enter some text, and press enter, the page reloads. This is obviously not good or expected. 

This patch fixes the problem by preventing the default form submission behaviour.