### PR TITLE
Platform-setting fixes

### DIFF
--- a/ide/static/ide/js/compile.js
+++ b/ide/static/ide/js/compile.js
@@ -721,7 +721,7 @@ CloudPebble.Compile = (function() {
                 } else {
                     if(CloudPebble.ProjectInfo.sdk_version == '3') {
                         if (!CloudPebble.ProjectInfo.app_platforms) {
-                            return ConnectionType.QemuChalk;
+                            return ConnectionType.QemuBasalt;
                         }
                         if (CloudPebble.ProjectInfo.app_platforms.indexOf('chalk') > -1) {
                             return ConnectionType.QemuChalk;

--- a/ide/static/ide/js/settings.js
+++ b/ide/static/ide/js/settings.js
@@ -15,6 +15,9 @@ CloudPebble.Settings = (function() {
         if(CloudPebble.ProjectInfo.type != 'native') {
             pane.find('.native-only').hide();
         }
+        if(CloudPebble.ProjectInfo.sdk_version != '3') {
+            pane.find('.sdk3-only').hide();
+        }
 
         var display_error = function(message) {
             pane.find('.alert').addClass('alert-error').removeClass('hide').text(message);
@@ -37,9 +40,9 @@ CloudPebble.Settings = (function() {
             var app_keys = {};
             var app_jshint = pane.find('#settings-app-jshint').prop("checked") ? 1 : 0;
             var menu_icon = pane.find('#settings-menu-image').val();
-            var build_aplite = pane.find('#settings-build-aplite').prop('checked');
-            var build_basalt = pane.find('#settings-build-basalt').prop('checked');
-            var build_chalk = pane.find('#settings-build-chalk').prop('checked');
+            var build_aplite = pane.find('#settings-build-aplite:visible').prop('checked');
+            var build_basalt = pane.find('#settings-build-basalt:visible').prop('checked');
+            var build_chalk = pane.find('#settings-build-chalk:visible').prop('checked');
 
             var app_is_hidden = 0;
             var app_is_shown_on_communication = 0;

--- a/ide/templates/ide/project/settings.html
+++ b/ide/templates/ide/project/settings.html
@@ -21,7 +21,7 @@
                 </div>
             </div>
         </div>
-        <div class="well native-only sdk3-only" {% if project.sdk_version == '2' %}style="display: none;"{% endif %}>
+        <div class="well sdk3-only">
             <div class="control-group">
                 {# Translators: "Aplite" is a platform name and should be left untranslated. #}
                 <label class="control-label" for="settings-build-aplite">{% trans 'Build Aplite' %}</label>
@@ -43,7 +43,7 @@
                     </span>
                 </div>
             </div>
-            <div class="control-group sdk3-only" {% if project.sdk_version == '2' %}style="display: none;"{% endif %}>
+            <div class="control-group native-only sdk3-only" >
                 {# Translators: "Chalk" is a platform name and should be left untranslated. #}
                 <label class="control-label" for="settings-build-chalk">{% trans 'Build Chalk' %}</label>
                 <div class="controls">


### PR DESCRIPTION
This PR makes basalt the default platform for new SDK3 & pebblejs projects, and also enables the targetPlatforms checkboxes for pebblejs