### PR TITLE
Show the currently running platform in the run button tooltip

### DIFF
--- a/ide/static/ide/js/editor.js
+++ b/ide/static/ide/js/editor.js
@@ -644,8 +644,18 @@ CloudPebble.Editor = (function() {
                             tooltip.append($(interpolate("<div><strong>%s: </strong>%s</div>", [gettext("Build for"), build_platform_names])));
                         }
                         var run_platform = CloudPebble.Compile.GetPlatformForInstall();
-                        var run_platform_name = capitalise_first_letter(run_platform == 1 ? gettext("Phone") : ConnectionPlatformNames[run_platform] + gettext(" Emulator"));
-                        tooltip.append(interpolate("<div><strong>%s: </strong>%s</div>", [gettext("Run on"), run_platform_name]));
+                        var run_platform_name;
+                        if (run_platform == ConnectionType.Phone) {
+                            run_platform_name = gettext("Phone");
+                        }
+                        else if (run_platform == ConnectionType.Qemu) {
+                            // If the emulator is already running, ask it directly what platform it's using
+                            run_platform_name = SharedPebble.getPlatformName() + gettext(" Emulator");
+                        }
+                        else {
+                            run_platform_name = ConnectionPlatformNames[run_platform] + gettext(" Emulator");
+                        }
+                        tooltip.append(interpolate("<div><strong>%s: </strong>%s</div>", [gettext("Run on"), capitalise_first_letter(run_platform_name)]));
 
                         return tooltip;
                     },

--- a/ide/static/ide/js/pebble.js
+++ b/ide/static/ide/js/pebble.js
@@ -212,6 +212,10 @@ var SharedPebble = new (function() {
         return mPebble && !!(mConnectionType & ConnectionType.Qemu);
     };
 
+    this.getPlatformName = function() {
+        return ConnectionPlatformNames[mConnectionType];
+    };
+
     function getWebsocketURL() {
         return (mConnectionType & ConnectionType.Qemu)? mEmulator.getWebsocketURL() : LIBPEBBLE_PROXY;
     }


### PR DESCRIPTION
A fix for the bug where the run button help tooltip wouldn't actually show you the correct platform if you were already running the emulator.