### PR TITLE
Fix for fullscreen click blurring issue

### DIFF
--- a/ide/static/ide/js/editor.js
+++ b/ide/static/ide/js/editor.js
@@ -194,7 +194,7 @@ CloudPebble.Editor = (function() {
 
                 // The browser should probably do this without our help. Sometimes Safari doesn't.
                 $(document).click(function(e) {
-                    if(!pane.find(e.target).length) {
+                    if(!is_fullscreen && !pane.find(e.target).length) {
                         $(code_mirror.display.input).blur();
                     }
                 });


### PR DESCRIPTION
A fix for a Safari issue where you could continue editing even after clicking outside of the editor was solved by forcibly blurring the editor if the click target was not found in the editor's parents' pane. However, the editor isn't inside its normal parent in fullscreen mode, so the fix would trigger even when you click in the editor.

This commit adds a check so that the fix only runs if fullscreen mode isn't active.