### PR TITLE
Start import when submitting project input form

### DIFF
--- a/ide/static/ide/js/project_list.js
+++ b/ide/static/ide/js/project_list.js
@@ -167,8 +167,8 @@ $(function() {
     };
 
     $('#run-import').click(run_project_import);
-    $('#import-prompt form').submit(function(event) {
-        event.preventDefault();
+    $('#import-prompt form').submit(function (e) {
+        e.preventDefault();
         $('#run-import').click();
     });
     

--- a/ide/static/ide/js/project_list.js
+++ b/ide/static/ide/js/project_list.js
@@ -167,7 +167,11 @@ $(function() {
     };
 
     $('#run-import').click(run_project_import);
-
+    $('#import-prompt form').submit(function(event) {
+        event.preventDefault();
+        $('#run-import').click();
+    });
+    
     $('#import-project').click(function() {
         $('#import-prompt').modal();
     });


### PR DESCRIPTION
Currently, pressing enter in the project-name field of the Import Project form just closes the dialog. This patch changes it so that it begins the import (as you would expect it to).