### PR TITLE
Corrected New file->target help box z-index

### DIFF
--- a/ide/static/ide/css/ide.css
+++ b/ide/static/ide/css/ide.css
@@ -1049,7 +1049,7 @@ span.cm-autofilled-end {
 }
 
 #help-prompt-holder {
-    z-index: 10001;
+    z-index: 10002;
     position: relative;
 }
 


### PR DESCRIPTION
A z-index of 10002 will ensure that it's drawn above the modal in all circumstances.

(Apparently the increase from 2000 to 10001 (#221) wasn't enough!)