### PR TITLE
Remember focus in IDE panes

### DIFF
--- a/ide/static/ide/js/fuzzyprompt.js
+++ b/ide/static/ide/js/fuzzyprompt.js
@@ -8,9 +8,10 @@ CloudPebble.FuzzyPrompt = (function() {
     var selected_id = null;
     var default_item;
     var selection_was_made;
+    var focus_pane;
     var opened = false;
     var COMMANDS_ENABLED = true;
-
+    var focus_pane_selector = '#main-pane'
     // While manual is false, always highlight the first item
     var manual = false;
 
@@ -171,6 +172,7 @@ CloudPebble.FuzzyPrompt = (function() {
         manual = false;
         selection_was_made = false;
         opened = true;
+        focus_pane = $(focus_pane_selector).get()[0];
         // Build up the list of files to search through
         var id = 0;
         _.each(sources, function(source) {
@@ -226,6 +228,11 @@ CloudPebble.FuzzyPrompt = (function() {
     // Hide the prompt and refocus on the last thing.
     var hide_prompt = function(refocus) {
         prompt.modal('hide');
+        // If we switched page, never refocus
+        if (focus_pane != $(focus_pane_selector).get()[0]) {
+            refocus = false;
+        }
+        // Otherwise, if we want to refocus, do so
         if (refocus) {
             setTimeout(function () {
                 $(previously_active).focus();

--- a/ide/static/ide/js/resources.js
+++ b/ide/static/ide/js/resources.js
@@ -458,7 +458,7 @@ CloudPebble.Resources = (function() {
             CloudPebble.ProgressBar.Hide();
             if(!data.success) return;
             var resource = data.resource;
-            var pane = prepare_resource_pane();
+            var pane = prepare_resource_pane({is_new: false});
 
             var list_entry = $('#sidebar-pane-resource-' + resource.id);
             var target_platforms_checkbox = pane.find("#edit-resource-target-platforms-enabled");
@@ -794,7 +794,8 @@ CloudPebble.Resources = (function() {
         return textext.textext()[0];
     };
 
-    var prepare_resource_pane = function() {
+    var prepare_resource_pane = function(options) {
+        var is_new = options.is_new;
         var template = resource_template.clone();
         template.removeClass('hide');
 
@@ -821,6 +822,9 @@ CloudPebble.Resources = (function() {
         template.find("#edit-resource-target-platforms-enabled").change(_.partial(show_resource_targets, template));
         template.find("#resource-targets-section input").change(function() {update_platform_labels(template);});
 
+        template.find('#edit-resource-type').attr('autofocus', is_new);
+        template.find('#edit-resource-file-name').attr('autofocus', !is_new);
+
         // setTimeout is used because the textarea has to actually be visible when the textext tag editor is initialised
         setTimeout(function() {
             var textext = build_tags_editor(template, template.find("#new-resource-tags"), []);
@@ -845,7 +849,7 @@ CloudPebble.Resources = (function() {
     var create_new_resource = function() {
         CloudPebble.Sidebar.SuspendActive();
         if(CloudPebble.Sidebar.Restore('new-resource')) return;
-        var pane = prepare_resource_pane();
+        var pane = prepare_resource_pane({is_new: true});
         var form = pane.find('form');
 
         form.submit(function(e) {

--- a/ide/static/ide/js/sidebar.js
+++ b/ide/static/ide/js/sidebar.js
@@ -39,6 +39,10 @@ CloudPebble.Sidebar = (function() {
         }
     };
 
+    var refocus_pane = function(pane) {
+        pane.find('*[autofocus]').first().focus();
+    };
+
     var restore_suspended_pane = function(id) {
         var pane = suspended_panes[id] ;
         if(pane) {
@@ -55,6 +59,8 @@ CloudPebble.Sidebar = (function() {
                 pane.data('pane-restore-function')();
             }
 
+            refocus_pane(pane);
+
             return true;
         }
         return false;
@@ -62,6 +68,7 @@ CloudPebble.Sidebar = (function() {
 
     var set_main_pane = function(pane, id, restore_function, destroy_function) {
         $('#main-pane').append(pane).data('pane-id', id);
+        refocus_pane(pane);
         if(restore_function) {
             $('#main-pane').data('pane-restore-function', restore_function);
         }

--- a/ide/static/ide/js/sidebar.js
+++ b/ide/static/ide/js/sidebar.js
@@ -13,12 +13,14 @@ CloudPebble.Sidebar = (function() {
         var pane = $('#main-pane');
 
         var suspend_function = pane.data('pane-suspend-function');
+
         if(suspend_function) suspend_function();
 
         var list_entry = $('#sidebar-pane-' + pane_id);
         if(list_entry) {
             list_entry.removeClass('active');
         }
+
         suspended_panes[pane_id] = pane;
         pane.detach();
         // Create a new empty one.
@@ -40,7 +42,10 @@ CloudPebble.Sidebar = (function() {
     };
 
     var refocus_pane = function(pane) {
-        pane.find('*[autofocus]').first().focus();
+        setTimeout(function() {
+            var previous_focus = pane.data('previous-focus');
+            (previous_focus || pane.find('*[autofocus]').first().focus()).focus();
+        }, 50);
     };
 
     var restore_suspended_pane = function(id) {
@@ -59,7 +64,7 @@ CloudPebble.Sidebar = (function() {
                 pane.data('pane-restore-function')();
             }
 
-            refocus_pane(pane);
+            refocus_pane($('#main-pane'));
 
             return true;
         }
@@ -68,7 +73,7 @@ CloudPebble.Sidebar = (function() {
 
     var set_main_pane = function(pane, id, restore_function, destroy_function) {
         $('#main-pane').append(pane).data('pane-id', id);
-        refocus_pane(pane);
+        refocus_pane($('#main-pane'));
         if(restore_function) {
             $('#main-pane').data('pane-restore-function', restore_function);
         }
@@ -162,6 +167,11 @@ CloudPebble.Sidebar = (function() {
             $('#sidebar-pane-github > a').click(CloudPebble.GitHub.Show);
             $('#sidebar-pane-timeline > a').click(CloudPebble.Timeline.show);
             $('#new-source-file').click(CloudPebble.Editor.Create);
+
+            $('#pane-parent').on('focusin', '#main-pane *', _.debounce(function(e) {
+                $('#main-pane').data('previous-focus', $(e.target));
+            }, 1));
+
             init();
         },
         SetPopover: function(pane_id, title, content) {

--- a/ide/templates/ide/project/compile.html
+++ b/ide/templates/ide/project/compile.html
@@ -56,7 +56,7 @@
         </div>
         <hr>
         <div class="build-buttons">
-            <button class="btn btn-affirmative" id="compilation-run-build-button">{% trans 'Run build' %}</button>
+            <button class="btn btn-affirmative" id="compilation-run-build-button" autofocus>{% trans 'Run build' %}</button>
             <a id="last-compilation-pbw" href="#" class="btn hide">{% trans 'Get PBW' %}</a>
             <a id="last-compilation-log" class="btn hide" href="#">{% trans 'Build log' %}</a>
         </div>

--- a/ide/templates/ide/project/github.html
+++ b/ide/templates/ide/project/github.html
@@ -7,7 +7,7 @@
             <div class="control-group">
                 <label class="control-label" for="github-repo">{% trans 'Github Repo' %}</label>
                 <div class="controls">
-                    <input type="text" class="span6" id="github-repo" pattern="(?:https?://|git@|git://)?(?:www\.)?github\.com[/:]([\w.-]+)/([\w.-]+?)(?:\.git|/|$)" placeholder="github.com/{{ project.owner.github.username }}/PebbleFace">
+                    <input type="text" class="span6" id="github-repo" pattern="(?:https?://|git@|git://)?(?:www\.)?github\.com[/:]([\w.-]+)/([\w.-]+?)(?:\.git|/|$)" placeholder="github.com/{{ project.owner.github.username }}/PebbleFace" autofocus>
                 </div>
             </div>
             <div class="control-group">

--- a/ide/templates/ide/project/resource.html
+++ b/ide/templates/ide/project/resource.html
@@ -7,7 +7,7 @@
             <div class="control-group">
                 <label class="control-label" for="edit-resource-type">{% trans 'Resource type' %}</label>
                 <div class="controls">
-                    <select id="edit-resource-type">
+                    <select id="edit-resource-type" autofocus>
                         <option value="png">{% trans 'PNG image' %}</option>
                         {% if project.project_type == 'native' %}
                         <option value="png-trans">{% trans 'PNG with transparency' %}</option>

--- a/ide/templates/ide/project/settings.html
+++ b/ide/templates/ide/project/settings.html
@@ -7,7 +7,7 @@
             <div class="control-group">
                 <label class="control-label" for="settings-name">{% trans 'Project name' %}</label>
                 <div class="controls">
-                    <input type="text" id="settings-name">
+                    <input type="text" id="settings-name" autofocus>
                 </div>
             </div>
             <div class="sdk-version native-only control-group">


### PR DESCRIPTION
With this PR, the sidebar manages which elements are automatically focussed when switching to a new pane inside the IDE. Specifically:

1) When an element in a pane is focussed on, it is recorded as the pane's last focussed element.
2) When switching back to the pane: if there was a saved element, it is refocussed. (second PR commit)
3) If there is not, the first element with an 'autofocus' attribute is focussed. (first PR commit)
4) If there is no autofocus element, the focus is unchanged.

The following gif demonstrates the new behaviour.

![autofocus](https://cloud.githubusercontent.com/assets/141427/11509670/51c805ca-9814-11e5-93a3-049c82cd27df.gif)

These changes make it much easier to navigate CloudPebble exclusively with the keyboard in that it's an improvement on the current state of tab-focus (when you switch to a new page and then click TAB, you focus on the navigation), but I'm not 100% sure that it's the best solution. Specifically, it might be better to just autofocus on the first form element every time, and not remember the previously focussed element.