### PR TITLE
Fix for certain log entries not showing

### DIFF
--- a/ide/static/ide/js/compile.js
+++ b/ide/static/ide/js/compile.js
@@ -377,7 +377,7 @@ CloudPebble.Compile = (function() {
     var append_log_html = function(html) {
         // Append the HTML line to the log
         var at_bottom = logs_scrolled_to_bottom();
-        mLogHolder.append(html.append("\n"));
+        mLogHolder.append($(html).append("\n"));
         // Then, scroll to the bottom if we were already scrolled to the bottom before.
         if (at_bottom) {
             mLogHolder[0].scrollTop = mLogHolder[0].scrollHeight - mLogHolder.outerHeight();


### PR DESCRIPTION
The append_log_html function now converts its argument to a jquery object before using it, solving a few cases where log entries were not actually appearing (e.g. [logs from here](https://github.com/pebble/cloudpebble/blob/d5f720875275a34892436684252f15c1496c1cdc/ide/static/ide/js/compile.js#L389))