### PR TITLE
Read and write worker_src files from Github

### DIFF
--- a/ide/tasks/archive.py
+++ b/ide/tasks/archive.py
@@ -133,6 +133,7 @@ def do_import_archive(project_id, archive, delete_project=False):
                 # - Parse resource_map.json and import files it references
                 MANIFEST = 'appinfo.json'
                 SRC_DIR = 'src/'
+                WORKER_SRC_DIR = 'worker_src/'
                 RES_PATH = 'resources'
 
                 if len(contents) > 400:
@@ -296,6 +297,12 @@ def do_import_archive(project_id, archive, delete_project=False):
                             if (not filename.startswith('.')) and (filename.endswith('.c') or filename.endswith('.h') or filename.endswith('.js')):
                                 base_filename = filename[len(SRC_DIR):]
                                 source = SourceFile.objects.create(project=project, file_name=base_filename)
+                                with z.open(entry.filename) as f:
+                                    source.save_file(f.read().decode('utf-8'))
+                        elif filename.startswith(WORKER_SRC_DIR):
+                            if (not filename.startswith('.')) and (filename.endswith('.c') or filename.endswith('.h') or filename.endswith('.js')):
+                                base_filename = filename[len(WORKER_SRC_DIR):]
+                                source = SourceFile.objects.create(project=project, file_name=base_filename, target='worker')
                                 with z.open(entry.filename) as f:
                                     source.save_file(f.read().decode('utf-8'))
                     project.save()

--- a/ide/tasks/git.py
+++ b/ide/tasks/git.py
@@ -85,10 +85,15 @@ def github_push(user, commit_message, repo_name, project):
         root = ''
 
     src_root = root + 'src/'
+    worker_src_root = root + 'worker_src/'
     project_sources = project.source_files.all()
     has_changed = False
     for source in project_sources:
-        repo_path = src_root + source.file_name
+        repo_path = ''
+        if source.target == 'worker':
+            repo_path = worker_src_root + source.file_name
+        else:
+            repo_path = src_root + source.file_name
         if repo_path not in next_tree:
             has_changed = True
             next_tree[repo_path] = InputGitTreeElement(path=repo_path, mode='100644', type='blob',


### PR DESCRIPTION
The goal here is to have Cloudpebble store worker app files in worker_src as is recommended for those using the SDK locally. I have tested importing from Github and files in worker_src are correctly read and given a target of 'worker'. Commiting to github is untested, but I believe it should place all files marked as 'worker' into worker_src.