### PR TITLE
Fix IB layer delete button bounds bug

### DIFF
--- a/ide/static/ide/js/ib/property_view.js
+++ b/ide/static/ide/js/ib/property_view.js
@@ -9,9 +9,10 @@
         this._parent = parent;
         this._layer = layer;
         this._root = $('<div class="form-horizontal">');
-        this._delete =
-            $('<div style="text-align: center;"><button class="btn btn-danger">' + gettext("Delete layer") + '</button></div>')
-                .on('click', _.bind(this._deleteLayer, this));
+        this._delete = $('<div style="text-align: center;"></div>');
+        $('<button class="btn btn-danger">' + gettext("Delete layer") + '</button>')
+            .on('click', _.bind(this._deleteLayer, this))
+            .appendTo(this._delete);
     };
     IB.PropertyView.prototype = {
         /**


### PR DESCRIPTION
The click handler for the layer delete button in the IB was attached to its parent div, meaning that it was possible to accidentally delete a layer (without confirmation) by clicking outside of the button.
This change moves the handler to the button itself.