### PR TITLE
Correctly delete files from S3

### DIFF
--- a/ide/models/files.py
+++ b/ide/models/files.py
@@ -353,7 +353,7 @@ def delete_file(sender, instance, **kwargs):
     if sender == SourceFile or sender == ResourceVariant:
         if settings.AWS_ENABLED:
             try:
-                s3.delete_file(instance.s3_path)
+                s3.delete_file('source', instance.s3_path)
             except:
                 traceback.print_exc()
         else:


### PR DESCRIPTION
This PR adds the missing bucket name argument to this call to s3.delete_file