### PR TITLE
Fixed github push cancel button

### DIFF
--- a/ide/templates/ide/project.html
+++ b/ide/templates/ide/project.html
@@ -251,7 +251,7 @@
             </div>
         </div>
         <div class="modal-footer">
-            <button class="btn" data-dismiss="modal">{% trans 'Cancel' %}</button>
+            <button type="button" class="btn" data-dismiss="modal">{% trans 'Cancel' %}</button>
             <input type="submit" class="btn btn-primary" value="{% trans 'Commit' %}">
         </div>
     </form>


### PR DESCRIPTION
The cancel button in the github push prompt would still cause a push, because the button's type wasn't defined. Setting it to "button" prevents this behaviour.
(Reported in #265)