### PR TITLE
Fix accidental JS global

### DIFF
--- a/ide/static/ide/js/libpebble/libpebble.js
+++ b/ide/static/ide/js/libpebble/libpebble.js
@@ -191,6 +191,7 @@ Pebble = function(proxy, token) {
     var mOutboundParser = new PebbleProtocolParser();
 
     var handle_message_from_watch = function(pdata) {
+        var data;
         mInboundParser.addBytes(pdata);
         while((data = mInboundParser.readMessage())) {
             var command = data.command;


### PR DESCRIPTION
This adds a missing `var` for a local variable.