### PR TITLE
Silence "'WebSocket' is not defined." when editing js files

### DIFF
--- a/ide/static/ide/js/editor.js
+++ b/ide/static/ide/js/editor.js
@@ -277,6 +277,7 @@ CloudPebble.Editor = (function() {
                         var jshint_globals = {
                             Pebble: true,
                             console: true,
+                            WebSocket: true,
                             XMLHttpRequest: true,
                             navigator: true, // For navigator.geolocation
                             localStorage: true,

--- a/ide/utils/sdk.py
+++ b/ide/utils/sdk.py
@@ -200,6 +200,7 @@ def generate_jshint_file(project):
   "globals": {
     "Pebble": true,
     "console": true,
+    "WebSocket": true,
     "XMLHttpRequest": true,
     "navigator": true, // For navigator.geolocation
     "localStorage": true,


### PR DESCRIPTION
Right now I have to add `/*global WebSocket*/` to the beginning of my app.js to get rid of `'WebSocket' is not defined.` I believe that this change will make that unnecessary.