### PR TITLE
PBL-35060 file rename can break YCM

### DIFF
--- a/ide/static/ide/js/editor.js
+++ b/ide/static/ide/js/editor.js
@@ -32,8 +32,9 @@ CloudPebble.Editor = (function() {
     };
 
     var rename_file = function(file, new_name) {
+        var old_name = file.name;
         // Check no-change or duplicate filenames
-        if (new_name == file.name) {
+        if (new_name == old_name) {
             return Promise.resolve();
         }
         if (project_source_files[new_name]) {
@@ -44,6 +45,12 @@ CloudPebble.Editor = (function() {
             new_name: new_name,
             modified: file.lastModified
         }).then(function(response) {
+            _.each(open_codemirrors, function(cm) {
+                if (cm.file_path == CloudPebble.YCM.pathForFilename(old_name, file.target)) {
+                    cm.file_path = CloudPebble.YCM.pathForFilename(new_name, file.target);
+                }
+            });
+            CloudPebble.YCM.renameFile(file, new_name);
             delete project_source_files[file.name];
             file.name = new_name;
             file.lastModified = response.modified;
@@ -192,7 +199,7 @@ CloudPebble.Editor = (function() {
                 settings.gutters = ['gutter-errors', 'CodeMirror-linenumbers', 'CodeMirror-foldgutter'];
             }
             var code_mirror = CodeMirror(pane[0], settings);
-            code_mirror.file_path = (file.target  == 'worker' ? 'worker_src/' : 'src/') + file.name;
+            code_mirror.file_path = CloudPebble.YCM.pathForFilename(file.name, file.target);
             code_mirror.file_target = file.target;
             code_mirror.parent_pane = pane;
             code_mirror.patch_list = [];

--- a/ide/static/ide/js/ycm.js
+++ b/ide/static/ide/js/ycm.js
@@ -138,6 +138,10 @@ CloudPebble.YCM = new (function() {
         });
     }
 
+    this.pathForFilename = function(file_name, target) {
+        return ((target == 'worker') ? 'worker_src/' : 'src/') + file_name;
+    };
+
     this.initialise = function() {
         if(mInitialised || mIsInitialising || mFailed) {
             return mInitPromise;
@@ -205,8 +209,15 @@ CloudPebble.YCM = new (function() {
             return Promise.resolve();
         }
         return ws_send('delete', {
-            filename: ((file.target == 'worker') ? 'worker_src/' : 'src/') + file.name
+            filename: (this.pathForFilename(file.name, file.target))
         });
+    };
+
+    this.renameFile = function(file, new_name) {
+        return ws_send('rename', {
+            filename: this.pathForFilename(file.name, file.target),
+            new_filename: this.pathForFilename(new_name, file.target)
+        })
     };
 
     this.createFile = function(file, content) {
@@ -214,7 +225,7 @@ CloudPebble.YCM = new (function() {
             return Promise.resolve();
         }
         return ws_send('create', {
-            filename: ((file.target == 'worker') ? 'worker_src/' : 'src/') + file.name,
+            filename: this.pathForFilename(file.name, file.target),
             content: content || ''
         });
     };


### PR DESCRIPTION
YCM proxy was missing the ability to rename files, so there were cases where autocompletions would break for a renamed file. After deploying https://github.com/pebble/cloudpebble-ycmd-proxy/pull/7, this PR will add the necessary clientside support.