### PR TITLE
Be specific with Python version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7
+FROM python:2.7.8
 MAINTAINER Katharine Berry <katharine@pebble.com>
 
 ENV NPM_CONFIG_LOGLEVEL=info NODE_VERSION=4.2.3 DJANGO_VERSION=1.6
@@ -25,6 +25,9 @@ RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-
   && tar -xzf "node-v$NODE_VERSION-linux-x64.tar.gz" -C /usr/local --strip-components=1 \
   && rm "node-v$NODE_VERSION-linux-x64.tar.gz" SHASUMS256.txt.asc
 
+# Upgrade pip
+RUN pip install --upgrade pip
+
 # Django stuff
 
 RUN apt-get update && apt-get install -y \
@@ -44,6 +47,7 @@ RUN curl -o /tmp/arm-cs-tools.tar https://cloudpebble-vagrant.s3.amazonaws.com/a
   tar -xf /tmp/arm-cs-tools.tar -C / && rm /tmp/arm-cs-tools.tar
 
 ADD requirements.txt /tmp/requirements.txt
+
 RUN pip install --no-cache-dir -r /tmp/requirements.txt
 
 ENV SDK_TWO_VERSION=2.9

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,6 @@ RUN curl -o /tmp/arm-cs-tools.tar https://cloudpebble-vagrant.s3.amazonaws.com/a
   tar -xf /tmp/arm-cs-tools.tar -C / && rm /tmp/arm-cs-tools.tar
 
 ADD requirements.txt /tmp/requirements.txt
-
 RUN pip install --no-cache-dir -r /tmp/requirements.txt
 
 ENV SDK_TWO_VERSION=2.9


### PR DESCRIPTION
CloudPebble currently uses Python 2.7.8 in production. We know that changes in Python patch versions can change behaviour which effects CloudPebble (e.g. SNI/SSL stuff introduced in 2.7.9) so we should be specific about the version of Python we develop with the Dockerfile.

A small side effect is that 2.7.8 ships with an older version of pip, which needs to be upgraded to support `pip install --no-cache-dir`.