### PR TITLE
Update ARM_CS_TOOLS to use correct value

### DIFF
--- a/app.json
+++ b/app.json
@@ -3,7 +3,7 @@
   "description": "CloudPebble Staging Configuration",
   "scripts": {},
   "env": {
-    "ARM_CS_TOOLS": "/app/sdk2/arm-cs-tools/bin/",
+    "ARM_CS_TOOLS": "/app/arm-cs-tools/bin/",
     "AWS_ACCESS_KEY_ID": {
       "required": true
     },


### PR DESCRIPTION
ARM_CS_TOOLS in production is set to `/app/arm-cs-tools/bin/`. The old value is now incorrect, causing staging/review apps to not be able to build apps.