### PR TITLE
Set default S3 bucket to `export.cloudpebble.net`

### DIFF
--- a/cloudpebble/settings.py
+++ b/cloudpebble/settings.py
@@ -308,7 +308,7 @@ AWS_SECRET_ACCESS_KEY = _environ.get('AWS_SECRET_ACCESS_KEY', None)
 
 AWS_S3_SOURCE_BUCKET = _environ.get('AWS_S3_SOURCE_BUCKET', 'source.cloudpebble.net')
 AWS_S3_BUILDS_BUCKET = _environ.get('AWS_S3_BUILDS_BUCKET', 'builds.cloudpebble.net')
-AWS_S3_EXPORT_BUCKET = _environ.get('AWS_S3_EXPORT_BUCKET', 'exports.cloudpebble.net')
+AWS_S3_EXPORT_BUCKET = _environ.get('AWS_S3_EXPORT_BUCKET', 'export.cloudpebble.net')
 AWS_S3_FAKE_S3 = _environ.get('AWS_S3_FAKE_S3', None)
 
 TYPOGRAPHY_CSS = _environ.get('TYPOGRAPHY_CSS', None)


### PR DESCRIPTION
`AWS_S3_EXPORT_BUCKET` should be 'export' not 'exports', to keep it in line with the value of `EXPORT_ROOT` in docker-compose.yml and with its value in production.