### PR TITLE
Removed printing of YCM requests

### DIFF
--- a/ide/api/ycm.py
+++ b/ide/api/ycm.py
@@ -55,7 +55,6 @@ def _choose_ycm_server():
 
 def _spin_up_server(request):
     servers = set(settings.YCM_URLS)
-    print request
     while len(servers) > 0:
         server = random.choice(list(servers))
         servers.remove(server)


### PR DESCRIPTION
Since project source files in their entirety are sent to YCM, this print statement results in huge quantities of code being printed into the logs and so should be removed.