### PR TITLE
Replace prints with logging module

### DIFF
--- a/cloudpebble/settings.py
+++ b/cloudpebble/settings.py
@@ -231,32 +231,42 @@ INSTALLED_APPS = (
     'djangobower',
 )
 
-# A sample logging configuration. The only tangible logging
-# performed by this configuration is to send an email to
-# the site admins on every HTTP 500 error when DEBUG=False.
-# See http://docs.djangoproject.com/en/dev/topics/logging for
-# more details on how to customize your logging configuration.
+# This logging config prints:
+# INFO logs from django
+# INFO or DEBUG logs from 'ide', depending on whether DEBUG=True
+# all WARNING logs from any sources
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
-    'filters': {
-        'require_debug_false': {
-            '()': 'django.utils.log.RequireDebugFalse'
-        }
+    'formatters': {
+        'verbose': {
+            'format': "[%(asctime)s] %(levelname)s [%(name)s:%(lineno)s] %(message)s",
+            'datefmt': "%d/%b/%Y %H:%M:%S"
+        },
     },
     'handlers': {
-        'mail_admins': {
-            'level': 'ERROR',
-            'filters': ['require_debug_false'],
-            'class': 'django.utils.log.AdminEmailHandler'
+        'console': {
+            'level': 'DEBUG',
+            'class': 'logging.StreamHandler',
+            'formatter': 'verbose'
         }
     },
     'loggers': {
-        'django.request': {
-            'handlers': ['mail_admins'],
-            'level': 'ERROR',
-            'propagate': True,
+        'django': {
+            'handlers': ['console'],
+            'level': 'INFO',
+            'propagate': True
         },
+        'ide': {
+            'handlers': ['console'],
+            'level': 'DEBUG' if DEBUG else 'INFO',
+            'propagate': True
+        },
+        '': {
+            'handlers': ['console'],
+            'level': 'WARNING',
+            'propagate': False
+        }
     }
 }
 

--- a/cloudpebble/settings.py
+++ b/cloudpebble/settings.py
@@ -7,6 +7,7 @@ import dj_database_url
 _environ = os.environ
 
 DEBUG = _environ.get('DEBUG', '') != ''
+VERBOSE = DEBUG or (_environ.get('VERBOSE', '') != '')
 TEMPLATE_DEBUG = DEBUG
 
 ADMINS = (
@@ -259,7 +260,7 @@ LOGGING = {
         },
         'ide': {
             'handlers': ['console'],
-            'level': 'DEBUG' if DEBUG else 'INFO',
+            'level': 'DEBUG' if VERBOSE else 'INFO',
             'propagate': True
         },
         '': {

--- a/ide/api/qemu.py
+++ b/ide/api/qemu.py
@@ -75,7 +75,7 @@ def launch_emulator(request):
             redis_client.set(redis_key, json.dumps(response))
             return json_response(response)
         except requests.HTTPError as e:
-            logger.warn("Got HTTP error from QEMU launch. Content:\n%s", e.response.text)
+            logger.warning("Got HTTP error from QEMU launch. Content:\n%s", e.response.text)
         except (requests.RequestException, ValueError) as e:
             logger.error("Error launching qemu: %s", e)
     return json_failure("Unable to create emulator instance.")

--- a/ide/api/ycm.py
+++ b/ide/api/ycm.py
@@ -1,4 +1,8 @@
 import json
+import logging
+import random
+
+import requests
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import get_object_or_404
@@ -8,11 +12,10 @@ from urlparse import urlparse
 
 from ide.api import json_response, json_failure
 from ide.models.project import Project
-import requests
-import random
-
 
 __author__ = 'katharine'
+
+logger = logging.getLogger(__name__)
 
 
 @login_required
@@ -32,7 +35,7 @@ def init_autocomplete(request, project_id):
             if f.kind == 'png-trans':
                 resource_ids.extend([
                     '#define RESOURCE_ID_%s_BLACK %d' % (identifier.resource_id, count),
-                    '#define RESOURCE_ID_%s_WHITE %d' % (identifier.resource_id, count+1)
+                    '#define RESOURCE_ID_%s_WHITE %d' % (identifier.resource_id, count + 1)
                 ])
                 count += 2
             else:
@@ -71,6 +74,6 @@ def _spin_up_server(request):
         except (requests.RequestException, ValueError):
             import traceback
             traceback.print_exc()
-        print "Server %s failed; trying another." % server
+        logger.warning("Server %s failed; trying another.", server)
     # If we get out of here, something went wrong.
     return json_failure({'success': False, 'error': 'No servers'})

--- a/ide/git.py
+++ b/ide/git.py
@@ -23,7 +23,7 @@ def git_auth_check(f):
         except BadCredentialsException:
             # Bad credentials; remove the user's auth data.
             try:
-                logger.warn("Bad credentials; revoking user's github tokens.")
+                logger.warning("Bad credentials; revoking user's github tokens.")
                 github = user.github
                 github.delete()
             except:

--- a/ide/git.py
+++ b/ide/git.py
@@ -1,13 +1,17 @@
-from ide.models.user import UserGithub
-from django.utils.translation import ugettext as _
-
-from github import Github, BadCredentialsException, UnknownObjectException
-from github.NamedUser import NamedUser
-from django.conf import settings
 import base64
 import json
 import urllib2
 import re
+import logging
+
+from github import Github, BadCredentialsException, UnknownObjectException
+from github.NamedUser import NamedUser
+from django.utils.translation import ugettext as _
+from django.conf import settings
+
+from ide.models.user import UserGithub
+
+logger = logging.getLogger(__name__)
 
 
 def git_auth_check(f):
@@ -19,12 +23,13 @@ def git_auth_check(f):
         except BadCredentialsException:
             # Bad credentials; remove the user's auth data.
             try:
-                print "Bad credentials; revoking user's github tokens."
+                logger.warn("Bad credentials; revoking user's github tokens.")
                 github = user.github
                 github.delete()
             except:
                 pass
             raise
+
     return g
 
 

--- a/ide/models/files.py
+++ b/ide/models/files.py
@@ -358,7 +358,7 @@ def delete_file(sender, instance, **kwargs):
             try:
                 s3.delete_file('source', instance.s3_path)
             except:
-                logging.exception("Failed to delete S3 file")
+                logger.exception("Failed to delete S3 file")
         else:
             try:
                 os.unlink(instance.local_filename)

--- a/ide/models/files.py
+++ b/ide/models/files.py
@@ -3,19 +3,22 @@ import shutil
 import traceback
 import datetime
 import json
+import logging
+
 from django.conf import settings
-from django.core.validators import RegexValidator
 from django.db import models
 from django.db.models.signals import post_delete
 from django.dispatch import receiver
 from django.utils.timezone import now
 from django.core.validators import RegexValidator
 from django.utils.translation import ugettext as _
-import utils.s3 as s3
 
+import utils.s3 as s3
 from ide.models.meta import IdeModel
 
 __author__ = 'katharine'
+
+logger = logging.getLogger(__name__)
 
 
 class ResourceFile(IdeModel):
@@ -355,7 +358,7 @@ def delete_file(sender, instance, **kwargs):
             try:
                 s3.delete_file('source', instance.s3_path)
             except:
-                traceback.print_exc()
+                logging.exception("Failed to delete S3 file")
         else:
             try:
                 os.unlink(instance.local_filename)

--- a/ide/tasks/archive.py
+++ b/ide/tasks/archive.py
@@ -237,18 +237,18 @@ def do_import_archive(project_id, archive, delete_project=False):
                             try:
                                 extracted = z.open("%s%s/%s" % (base_dir, RES_PATH, base_filename))
                             except KeyError:
-                                logging.debug("Failed to open %s", base_filename)
+                                logger.debug("Failed to open %s", base_filename)
                                 continue
 
                             # Now we know the file exists and is in the resource directory - is it the one we want?
                             tags, root_file_name = get_filename_variant(base_filename, tag_map)
                             tags_string = ",".join(str(int(t)) for t in tags)
 
-                            logging.debug("Importing file %s with root %s ", entry.filename, root_file_name)
+                            logger.debug("Importing file %s with root %s ", entry.filename, root_file_name)
 
                             if root_file_name in desired_resources:
                                 medias = desired_resources[root_file_name]
-                                logging.debug("Looking for variants of %s", root_file_name)
+                                logger.debug("Looking for variants of %s", root_file_name)
 
                                 # Because 'kind' and 'is_menu_icons' are properties of ResourceFile in the database,
                                 # we just use the first one.

--- a/ide/tasks/archive.py
+++ b/ide/tasks/archive.py
@@ -5,20 +5,24 @@ import tempfile
 import uuid
 import zipfile
 import json
+import logging
+
 from celery import task
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.exceptions import SuspiciousOperation
 from django.db import transaction
+
 from ide.utils.project import find_project_root
 from ide.utils.sdk import generate_manifest, generate_wscript_file, generate_jshint_file, dict_to_pretty_json
 from utils.td_helper import send_td_event
-
 from ide.models.files import SourceFile, ResourceFile, ResourceIdentifier, ResourceVariant
 from ide.models.project import Project
 import utils.s3 as s3
 
 __author__ = 'katharine'
+
+logger = logging.getLogger(__name__)
 
 
 def add_project_to_archive(z, project, prefix=''):
@@ -105,7 +109,7 @@ def get_filename_variant(file_name, resource_suffix_map):
     split = file_name_parts[0].split("~")
     tags = split[1:]
     try:
-        ids = [resource_suffix_map['~'+tag] for tag in tags]
+        ids = [resource_suffix_map['~' + tag] for tag in tags]
     except KeyError as key:
         raise ValueError('Unrecognised tag %s' % key)
     root_file_name = split[0] + file_name_parts[1]
@@ -145,7 +149,6 @@ def do_import_archive(project_id, archive, delete_project=False):
                 if len(contents) > 400:
                     raise Exception("Too many files in zip file.")
                 file_list = [x.filename for x in contents]
-
 
                 base_dir = find_project_root(file_list)
                 dir_end = len(base_dir)
@@ -214,7 +217,7 @@ def do_import_archive(project_id, archive, delete_project=False):
                                     raise ValueError("Generic resource filenames cannot contain a tilde (~)")
                                 if file_name not in desired_resources:
                                     desired_resources[root_file_name] = []
-                                print "Desired resource: %s" % root_file_name
+
                                 desired_resources[root_file_name].append(resource)
                                 file_exists_for_root[root_file_name] = False
 
@@ -223,22 +226,22 @@ def do_import_archive(project_id, archive, delete_project=False):
                                 filename = make_valid_filename(zipitem)
                                 if filename is False or not filename.startswith(RES_PATH):
                                     continue
-                                filename = filename[len(RES_PATH)+1:]
+                                filename = filename[len(RES_PATH) + 1:]
                                 try:
-                                    extracted = z.open("%s%s/%s"%(base_dir, RES_PATH, filename))
+                                    extracted = z.open("%s%s/%s" % (base_dir, RES_PATH, filename))
                                 except KeyError:
-                                    print "Failed to open %s" % filename
+                                    logger.debug("Failed to open %s", filename)
                                     continue
 
                                 # Now we know the file exists and is in the resource directory - is it one we want?
                                 tags, root_file_name = get_filename_variant(filename, tag_map)
                                 tags_string = ",".join(str(int(t)) for t in tags)
 
-                                print "Importing file %s with root %s " % (zipitem.filename, root_file_name)
+                                logger.debug("Importing file %s with root %s ", zipitem.filename, root_file_name)
 
                                 if root_file_name in desired_resources:
                                     medias = desired_resources[root_file_name]
-                                    print "Looking for variants of %s" % root_file_name
+                                    logger.debug("Looking for variants of %s", root_file_name)
 
                                     # Because 'kind' and 'is_menu_icons' are properties of ResourceFile in the database,
                                     # we just use the first one.
@@ -254,7 +257,7 @@ def do_import_archive(project_id, archive, delete_project=False):
                                             is_menu_icon=is_menu_icon)
 
                                     # But add a resource variant for every file
-                                    print "Adding variant %s with tags [%s]" % (root_file_name, tags_string)
+                                    logger.debug("Adding variant %s with tags [%s]", root_file_name, tags_string)
                                     actual_file_name = resource['file']
                                     resource_variants[actual_file_name] = ResourceVariant.objects.create(resource_file=resources_files[root_file_name], tags=tags_string)
                                     resource_variants[actual_file_name].save_file(extracted)

--- a/ide/tasks/build.py
+++ b/ide/tasks/build.py
@@ -189,7 +189,7 @@ def run_compile(build_result):
                                              env=environ)
         except subprocess.CalledProcessError as e:
             output = e.output
-            logger.warn("Build command failed with error:\n%s\n", output)
+            logger.warning("Build command failed with error:\n%s\n", output)
             success = False
         except Exception as e:
             success = False
@@ -199,7 +199,7 @@ def run_compile(build_result):
             temp_file = os.path.join(base_dir, 'build', '%s.pbw' % os.path.basename(base_dir))
             if not os.path.exists(temp_file):
                 success = False
-                logger.warn("Success was a lie.")
+                logger.warning("Success was a lie.")
         finally:
             build_end_time = now()
             os.chdir(cwd)
@@ -216,7 +216,7 @@ def run_compile(build_result):
                         store_size_info(project, build_result, 'chalk', z)
 
                 except Exception as e:
-                    logger.warn("Couldn't extract filesizes: %s", e)
+                    logger.warning("Couldn't extract filesizes: %s", e)
 
                 # Try pulling out debug information.
                 if project.sdk_version == '2':

--- a/ide/tasks/build.py
+++ b/ide/tasks/build.py
@@ -2,10 +2,10 @@ import os
 import shutil
 import subprocess
 import tempfile
-import traceback
 import zipfile
 import json
 import resource
+import logging
 
 from celery import task
 
@@ -23,12 +23,14 @@ from ide.utils.prepreprocessor import process_file as check_preprocessor_directi
 
 __author__ = 'katharine'
 
+logger = logging.getLogger(__name__)
+
 
 def _set_resource_limits():
-    resource.setrlimit(resource.RLIMIT_CPU, (20, 20)) # 20 seconds of CPU time
-    resource.setrlimit(resource.RLIMIT_NOFILE, (100, 100)) # 100 open files
-    resource.setrlimit(resource.RLIMIT_RSS, (20 * 1024 * 1024, 20 * 1024 * 1024)) # 20 MB of memory
-    resource.setrlimit(resource.RLIMIT_FSIZE, (5 * 1024 * 1024, 5 * 1024 * 1024)) # 5 MB output files.
+    resource.setrlimit(resource.RLIMIT_CPU, (20, 20))  # 20 seconds of CPU time
+    resource.setrlimit(resource.RLIMIT_NOFILE, (100, 100))  # 100 open files
+    resource.setrlimit(resource.RLIMIT_RSS, (20 * 1024 * 1024, 20 * 1024 * 1024))  # 20 MB of memory
+    resource.setrlimit(resource.RLIMIT_FSIZE, (5 * 1024 * 1024, 5 * 1024 * 1024))  # 5 MB output files.
 
 
 def create_source_files(project, base_dir):
@@ -76,7 +78,8 @@ def save_debug_info(base_dir, build_result, kind, platform, elf_file):
         try:
             debug_info = apptools.addr2lines.create_coalesced_group(path)
         except:
-            print traceback.format_exc()
+            # This will print the traceback
+            logger.exception("Failed to save debug info.")
         else:
             build_result.save_debug_info(debug_info, platform, kind)
 
@@ -186,7 +189,7 @@ def run_compile(build_result):
                                              env=environ)
         except subprocess.CalledProcessError as e:
             output = e.output
-            print output
+            logger.warn("Build command failed with error:\n%s\n", output)
             success = False
         except Exception as e:
             success = False
@@ -196,7 +199,7 @@ def run_compile(build_result):
             temp_file = os.path.join(base_dir, 'build', '%s.pbw' % os.path.basename(base_dir))
             if not os.path.exists(temp_file):
                 success = False
-                print "Success was a lie."
+                logger.warn("Success was a lie.")
         finally:
             build_end_time = now()
             os.chdir(cwd)
@@ -213,7 +216,7 @@ def run_compile(build_result):
                         store_size_info(project, build_result, 'chalk', z)
 
                 except Exception as e:
-                    print "Couldn't extract filesizes: %s" % e
+                    logger.warn("Couldn't extract filesizes: %s", e)
 
                 # Try pulling out debug information.
                 if project.sdk_version == '2':
@@ -226,7 +229,6 @@ def run_compile(build_result):
                     save_debug_info(base_dir, build_result, BuildResult.DEBUG_WORKER, 'basalt', os.path.join(base_dir, 'build', 'basalt/pebble-worker.elf'))
                     save_debug_info(base_dir, build_result, BuildResult.DEBUG_APP, 'chalk', os.path.join(base_dir, 'build', 'chalk/pebble-app.elf'))
                     save_debug_info(base_dir, build_result, BuildResult.DEBUG_WORKER, 'chalk', os.path.join(base_dir, 'build', 'chalk/pebble-worker.elf'))
-
 
                 build_result.save_pbw(temp_file)
             build_result.save_build_log(output)
@@ -249,8 +251,7 @@ def run_compile(build_result):
             send_td_event(event_name, data, project=project)
 
     except Exception as e:
-        print "Build failed due to internal error: %s" % e
-        traceback.print_exc()
+        logger.exception("Build failed due to internal error: %s", e)
         build_result.state = BuildResult.STATE_FAILED
         build_result.finished = now()
         try:
@@ -260,4 +261,4 @@ def run_compile(build_result):
         build_result.save()
     finally:
         # shutil.rmtree(base_dir)
-        print base_dir
+        logger.debug("base_dir: %s", base_dir)

--- a/ide/tasks/git.py
+++ b/ide/tasks/git.py
@@ -2,11 +2,14 @@ import base64
 import urllib2
 import json
 import os
+import logging
+
 from celery import task
 from django.conf import settings
 from django.utils.timezone import now
 from github.GithubObject import NotSet
 from github import Github, GithubException, InputGitTreeElement
+
 from ide.git import git_auth_check, get_github
 from ide.models.build import BuildResult
 from ide.models.project import Project
@@ -17,6 +20,8 @@ from ide.utils.sdk import generate_manifest_dict, generate_manifest, generate_ws
 from utils.td_helper import send_td_event
 
 __author__ = 'katharine'
+
+logger = logging.getLogger(__name__)
 
 
 @task(acks_late=True)
@@ -108,13 +113,13 @@ def github_push(user, commit_message, repo_name, project):
             has_changed = True
             next_tree[repo_path] = InputGitTreeElement(path=repo_path, mode='100644', type='blob',
                                                        content=source.get_contents())
-            print "New file: %s" % repo_path
+            logger.debug("New file: %s", repo_path)
         else:
             sha = next_tree[repo_path]._InputGitTreeElement__sha
             our_content = source.get_contents()
             expected_sha = git_sha(our_content)
             if expected_sha != sha:
-                print "Updated file: %s" % repo_path
+                logger.debug("Updated file: %s", repo_path)
                 next_tree[repo_path]._InputGitTreeElement__sha = NotSet
                 next_tree[repo_path]._InputGitTreeElement__content = our_content
                 has_changed = True
@@ -129,16 +134,16 @@ def github_push(user, commit_message, repo_name, project):
             if repo_path in next_tree:
                 content = variant.get_contents()
                 if git_sha(content) != next_tree[repo_path]._InputGitTreeElement__sha:
-                    print "Changed resource: %s" % repo_path
+                    logger.debug("Changed resource: %s", repo_path)
                     has_changed = True
                     blob = repo.create_git_blob(base64.b64encode(content), 'base64')
-                    print "Created blob %s" % blob.sha
+                    logger.debug("Created blob %s", blob.sha)
                     next_tree[repo_path]._InputGitTreeElement__sha = blob.sha
             else:
-                print "New resource: %s" % repo_path
+                logger.debug("New resource: %s", repo_path)
                 has_changed = True
                 blob = repo.create_git_blob(base64.b64encode(variant.get_contents()), 'base64')
-                print "Created blob %s" % blob.sha
+                logger.debug("Created blob %s", blob.sha)
                 next_tree[repo_path] = InputGitTreeElement(path=repo_path, mode='100644', type='blob', sha=blob.sha)
 
     # Manage deleted files
@@ -147,7 +152,7 @@ def github_push(user, commit_message, repo_name, project):
             continue
         if path not in expected_paths:
             del next_tree[path]
-            print "Deleted file: %s" % path
+            logger.debug("Deleted file: %s", path)
             has_changed = True
 
     # Compare the resource dicts
@@ -166,14 +171,14 @@ def github_push(user, commit_message, repo_name, project):
     our_res_dict = our_manifest_dict['resources']
 
     if our_res_dict != their_res_dict:
-        print "Resources mismatch."
+        logger.debug("Resources mismatch.")
         has_changed = True
         # Try removing things that we've deleted, if any
         to_remove = set(x['file'] for x in their_res_dict['media']) - set(x['file'] for x in our_res_dict['media'])
         for path in to_remove:
             repo_path = resource_root + path
             if repo_path in next_tree:
-                print "Deleted resource: %s" % repo_path
+                logger.debug("Deleted resource: %s", repo_path)
                 del next_tree[repo_path]
 
     # This one is separate because there's more than just the resource map changing.
@@ -193,22 +198,22 @@ def github_push(user, commit_message, repo_name, project):
 
     # Commit the new tree.
     if has_changed:
-        print "Has changed; committing"
+        logger.debug("Has changed; committing")
         # GitHub seems to choke if we pass the raw directory nodes off to it,
         # so we delete those.
         for x in next_tree.keys():
             if next_tree[x]._InputGitTreeElement__mode == '040000':
                 del next_tree[x]
-                print "removing subtree node %s" % x
+                logger.debug("removing subtree node %s", x)
 
-        print [x._InputGitTreeElement__mode for x in next_tree.values()]
+        logger.debug([x._InputGitTreeElement__mode for x in next_tree.values()])
         git_tree = repo.create_git_tree(next_tree.values())
-        print "Created tree %s" % git_tree.sha
+        logger.debug("Created tree %s", git_tree.sha)
         git_commit = repo.create_git_commit(commit_message, git_tree, [commit])
-        print "Created commit %s" % git_commit.sha
+        logger.debug("Created commit %s", git_commit.sha)
         git_ref = repo.get_git_ref('heads/%s' % (project.github_branch or repo.master_branch))
         git_ref.edit(git_commit.sha)
-        print "Updated ref %s" % git_ref.ref
+        logger.debug("Updated ref %s", git_ref.ref)
         project.github_last_commit = git_commit.sha
         project.github_last_sync = now()
         project.save()
@@ -270,7 +275,7 @@ def github_pull(user, project):
     for resource in media:
         path = resource_root + resource['file']
         if project_type == 'pebblejs' and resource['name'] in {
-                'MONO_FONT_14', 'IMAGE_MENU_ICON', 'IMAGE_LOGO_SPLASH', 'IMAGE_TILE_SPLASH'}:
+            'MONO_FONT_14', 'IMAGE_MENU_ICON', 'IMAGE_LOGO_SPLASH', 'IMAGE_TILE_SPLASH'}:
             continue
         if path not in paths_notags:
             raise Exception("Resource %s not found in repo." % path)
@@ -315,7 +320,7 @@ def do_github_pull(project_id):
 def hooked_commit(project_id, target_commit):
     project = Project.objects.select_related('owner__github').get(pk=project_id)
     did_something = False
-    print "Comparing %s versus %s" % (project.github_last_commit, target_commit)
+    logger.debug("Comparing %s versus %s", project.github_last_commit, target_commit)
     if project.github_last_commit != target_commit:
         github_pull(project.owner, project)
         did_something = True

--- a/ide/utils/mailinglist.py
+++ b/ide/utils/mailinglist.py
@@ -3,6 +3,8 @@ import mailchimp
 
 from django.conf import settings
 
+logger = logging.getLogger(__name__)
+
 mailchimp_default_list_id = settings.MAILCHIMP_LIST_ID
 
 
@@ -10,12 +12,12 @@ def add_user(user, mailing_list_id=None):
     try:
         mailchimp_api = mailchimp.Mailchimp(apikey=settings.MAILCHIMP_API_KEY)
     except mailchimp.Error:
-        logging.error("Missing or invalid MAILCHIMP_API_KEY")
+        logger.error("Missing or invalid MAILCHIMP_API_KEY")
         return
 
     list_id = mailing_list_id or mailchimp_default_list_id
     if list_id is None:
-        logging.error("Missing MAILCHIMP_LIST_ID")
+        logger.error("Missing MAILCHIMP_LIST_ID")
         return
 
     try:
@@ -24,10 +26,10 @@ def add_user(user, mailing_list_id=None):
                                                  double_optin=False,
                                                  update_existing=False,
                                                  replace_interests=False)
-        logging.debug("{} was successfully subscribed to list {}".format(response['email'], list_id))
+        logger.debug("{} was successfully subscribed to list {}".format(response['email'], list_id))
     except mailchimp.ListDoesNotExistError:
-        logging.error("List {} does not exist".format(list_id))
+        logger.error("List {} does not exist".format(list_id))
     except mailchimp.ListAlreadySubscribedError:
-        logging.info("User already subscribed to list {}".format(list_id))
+        logger.info("User already subscribed to list {}".format(list_id))
     except mailchimp.Error as e:
-        logging.error("An error occurred: {} - {}".format(e.__class__, e))
+        logger.error("An error occurred: {} - {}".format(e.__class__, e))

--- a/ide/utils/project.py
+++ b/ide/utils/project.py
@@ -1,30 +1,35 @@
-__author__ = 'katharine'
+import logging
+
 from django.utils.translation import ugettext as _
+
+__author__ = 'katharine'
+
+logger = logging.getLogger(__name__)
 
 
 def find_project_root(contents):
     MANIFEST = 'appinfo.json'
     SRC_DIR = 'src/'
     for base_dir in contents:
-        print base_dir
+        logger.debug("base_dir: %s", base_dir)
         try:
             dir_end = base_dir.index(MANIFEST)
-            print dir_end
+            logger.debug("dir_end: %s", dir_end)
         except ValueError:
             continue
         else:
             if dir_end + len(MANIFEST) != len(base_dir):
-                print 'failed'
+                logger.debug('failed')
                 continue
 
         base_dir = base_dir[:dir_end]
-        print base_dir
+        logger.debug("base_dir: %s", base_dir)
         for source_dir in contents:
             if source_dir[:dir_end] != base_dir:
                 continue
             if not source_dir.endswith('.c') and not source_dir.endswith('.js'):
                 continue
-            if source_dir[dir_end:dir_end+len(SRC_DIR)] != SRC_DIR:
+            if source_dir[dir_end:dir_end + len(SRC_DIR)] != SRC_DIR:
                 continue
             break
         else:

--- a/utils/s3.py
+++ b/utils/s3.py
@@ -1,8 +1,12 @@
+import logging
+
 import boto
 from boto.s3.key import Key
 from boto.s3.connection import OrdinaryCallingFormat
 from django.conf import settings
-import urllib
+
+logger = logging.getLogger(__name__)
+
 
 def _ensure_bucket_exists(s3, bucket):
     try:
@@ -10,7 +14,8 @@ def _ensure_bucket_exists(s3, bucket):
     except boto.exception.S3ResponseError:
         pass
     else:
-        print "Created bucket %s" % bucket
+        logger.info("Created bucket %s" % bucket)
+
 
 if settings.AWS_ENABLED:
     if settings.AWS_S3_FAKE_S3 is None:
@@ -40,6 +45,7 @@ def _requires_aws(fn):
     else:
         def complain(*args, **kwargs):
             raise Exception("AWS_ENABLED must be True to call %s" % fn.__name__)
+
         return complain
 
 
@@ -56,11 +62,13 @@ def read_file_to_filesystem(bucket_name, path, destination):
     key = bucket.get_key(path)
     key.get_contents_to_filename(destination)
 
+
 @_requires_aws
 def delete_file(bucket_name, path):
     bucket = _buckets[bucket_name]
     key = bucket.get_key(path)
     key.delete()
+
 
 @_requires_aws
 def save_file(bucket_name, path, value, public=False, content_type='application/octet-stream'):
@@ -92,7 +100,7 @@ def upload_file(bucket_name, dest_path, src_path, public=False, content_type='ap
     }
 
     if download_filename is not None:
-        headers['Content-Disposition'] = 'attachment;filename="%s"' % download_filename.replace(' ','_')
+        headers['Content-Disposition'] = 'attachment;filename="%s"' % download_filename.replace(' ', '_')
 
     key.set_contents_from_filename(src_path, policy=policy, headers=headers)
 


### PR DESCRIPTION
This PR replaces all print statements with the logging module. Each module which had print statements now instantiates a logger with `logger = logging.getLogger(__name__)` and uses `logger.info`/`.warning`/etc.

Besides adding the ability to filter log output by level, there are two other advantages to using logging everywhere.

- Docker did not seem to play well with print statements. Output from print statements seems to be buffered somewhere and output sporadically or when docker processes are killed.
- All output messages will have timestamps, module names, log levels and line numbers
- We can more easily add more handlers to send errors to monitoring systems.

I made some judgement calls on which messages have which levels, and which messages from which sources get printed in development vs production. I currently have set it up so that debug messages from our own code will not be printed in production, but anything>=INFO will be.

(I also took the opportunity to commit a few formatting and import-order fixes)

(Dependant on #299 )