### PR TITLE
Emulator toggle

### DIFF
--- a/cloudpebble/settings.py
+++ b/cloudpebble/settings.py
@@ -321,6 +321,7 @@ COMPLETION_CERTS = _environ.get('COMPLETION_CERTS', os.getcwd() + '/completion-c
 QEMU_URLS = _environ.get('QEMU_URLS', 'http://qemu/').split(',')
 QEMU_LAUNCH_AUTH_HEADER = _environ.get('QEMU_LAUNCH_AUTH_HEADER', 'secret')
 QEMU_LAUNCH_TIMEOUT = int(_environ.get('QEMU_LAUNCH_TIMEOUT', 15))
+QEMU_DISABLED = _environ.get('QEMU_DISABLED', False)
 
 PHONE_SHORTURL = _environ.get('PHONE_SHORTURL', 'cpbl.io')
 

--- a/ide/static/ide/js/compile.js
+++ b/ide/static/ide/js/compile.js
@@ -273,7 +273,7 @@ CloudPebble.Compile = (function() {
                     }
                     // Only enable emulator buttons for built platforms.
                     pane.find('#run-qemu .btn-primary').attr('disabled', function() {
-                        return !_.isObject(build.sizes[$(this).data('platform')]);
+                        return QEMU_DISABLED ? true : !_.isObject(build.sizes[$(this).data('platform')]);
                     })
                 }
             } else {

--- a/ide/templates/ide/project.html
+++ b/ide/templates/ide/project.html
@@ -476,6 +476,7 @@ var USER_SETTINGS = {
 };
 var DOC_JSON = "{% static 'ide/documentation.json' %}";
 var LIBPEBBLE_PROXY = {{ libpebble_proxy | safe }};
+var QEMU_DISABLED = {{ qemu_disabled|yesno:"true,false"}};
 </script>
 <script src="{% static 'CodeMirror/lib/codemirror.js' %}"></script>
 <script src="{% static 'CodeMirror/addon/dialog/dialog.js' %}"></script>

--- a/ide/templates/ide/project/compile.html
+++ b/ide/templates/ide/project/compile.html
@@ -26,6 +26,9 @@
                     </div>
                     <div id="run-qemu" class="tab-pane active">
                         <hr>
+                        {% if qemu_disabled %}
+                        <span>Emulators are currently unavailable due to technical issues. Please try again later.</span>
+                        {% endif %}
                         <div>
                             <button class="btn btn-primary" id="install-in-qemu-aplite-btn" data-platform="aplite">Aplite</button>
                             <button class="btn btn-primary" id="install-in-qemu-basalt-btn" data-platform="basalt">Basalt</button>

--- a/ide/views/project.py
+++ b/ide/views/project.py
@@ -47,7 +47,8 @@ def view_project(request, project_id):
         'libpebble_proxy': json.dumps(settings.LIBPEBBLE_PROXY),
         'token': token,
         'phone_shorturl': settings.PHONE_SHORTURL,
-        'supported_platforms': supported_platforms
+        'supported_platforms': supported_platforms,
+        'qemu_disabled': bool(settings.QEMU_DISABLED)
     })
 
 


### PR DESCRIPTION
This adds the env var `QEMU_DISABLED` which, when set, will disable the emulator buttons in CloudPebble and show a message above them.
(Users may still try to run emulators using the green button, but presumably with this in place they'll eventually figure out that something is wrong)

