### PR TITLE
Enable testing with Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: python
+python: "2.7"
+sudo: false
+services:
+  - rabbitmq
+  - postgresql
+before_script:
+  - psql -c "CREATE DATABASE travisci;" -U postgres
+install:
+  - pip install -r requirements.txt
+script: python manage.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,5 @@ before_script:
 install:
   - pip install -r requirements.txt
 script: python manage.py test
+env:
+  - AWS_ENABLED=yes

--- a/cloudpebble/settings.py
+++ b/cloudpebble/settings.py
@@ -19,7 +19,18 @@ SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
 MANAGERS = ADMINS
 
-if 'DATABASE_URL' not in _environ:
+if 'TRAVIS' in _environ:
+    DATABASES = {
+        'default': {
+            'ENGINE':   'django.db.backends.postgresql_psycopg2',
+            'NAME':     'travisci',
+            'USER':     'postgres',
+            'PASSWORD': '',
+            'HOST':     'localhost',
+            'PORT':     '',
+        }
+    }
+elif 'DATABASE_URL' not in _environ:
     DATABASES = {
         'default': {
             'ENGINE': 'django.db.backends.postgresql_psycopg2',

--- a/ide/tests/test_git.py
+++ b/ide/tests/test_git.py
@@ -3,7 +3,7 @@ Tests in this file can be run with run_tests.py
 """
 
 from django.test import TestCase
-import git
+import ide.git
 
 
 class UrlToReposTest(TestCase):
@@ -11,7 +11,7 @@ class UrlToReposTest(TestCase):
         """
         Tests that a simple repo url is correctly recognized.
         """
-        username, reponame = git.url_to_repo("https://github.com/pebble/cloudpebble")
+        username, reponame = ide.git.url_to_repo("https://github.com/pebble/cloudpebble")
         self.assertEqual("pebble", username)
         self.assertEqual("cloudpebble", reponame)
 
@@ -19,7 +19,7 @@ class UrlToReposTest(TestCase):
         """
         Tests that a non-standard repo url is correctly recognized.
         """
-        username, reponame  = git.url_to_repo("git://github.com:foo/bar.git")
+        username, reponame = ide.git.url_to_repo("git://github.com:foo/bar.git")
         self.assertEqual("foo", username)
         self.assertEqual("bar", reponame)
 
@@ -27,4 +27,4 @@ class UrlToReposTest(TestCase):
         """
         Tests that a entirely different url returns None.
         """
-        self.assertEqual(None, git.url_to_repo("http://www.cuteoverload.com"))
+        self.assertEqual(None, ide.git.url_to_repo("http://www.cuteoverload.com"))

--- a/ide/tests/test_source_api.py
+++ b/ide/tests/test_source_api.py
@@ -7,12 +7,6 @@ from django.utils.datastructures import MultiValueDictKeyError
 from ide.utils.cloudpebble_test import CloudpebbleTestCase
 from utils.fakes import FakeS3
 
-try:
-    from django.test import override_settings
-except ImportError:
-    # TODO: Remove Django 1.6 compatibility after move to Django 1.9
-    from django.test.utils import override_settings
-
 __author__ = 'joe'
 
 fake_s3 = FakeS3()

--- a/ide/tests/test_source_api.py
+++ b/ide/tests/test_source_api.py
@@ -19,7 +19,7 @@ fake_s3 = FakeS3()
 
 
 @mock.patch('ide.models.files.s3', fake_s3)
-class TestsSource(CloudpebbleTestCase):
+class TestSource(CloudpebbleTestCase):
     """Tests for the Tests models"""
 
     def setUp(self):
@@ -102,7 +102,6 @@ class TestsSource(CloudpebbleTestCase):
         loaded = self.load_file(info['id'])
         self.assertEqual(new_content, loaded['source'])
 
-
     def test_create_with_invalid_target_throws_error(self):
         """ Test that attempting to create a file with an invalid target throws an error """
         with self.assertRaises(ValidationError):
@@ -136,5 +135,5 @@ class TestsSource(CloudpebbleTestCase):
         name2 = "name2.c"
         info = self.create_file(name1)
         loaded = self.load_file(info['id'])
-        self.rename_file(info['id'], int(loaded['modified']-5000), name1, name2, success=False)
+        self.rename_file(info['id'], int(loaded['modified'] - 5000), name1, name2, success=False)
         self.assertIn(name1, self.get_source_names())

--- a/ide/tests/test_source_api.py
+++ b/ide/tests/test_source_api.py
@@ -1,0 +1,140 @@
+import json
+
+import mock
+from django.core.urlresolvers import reverse
+from django.core.exceptions import ValidationError
+from django.utils.datastructures import MultiValueDictKeyError
+from ide.utils.cloudpebble_test import CloudpebbleTestCase
+from utils.fakes import FakeS3
+
+try:
+    from django.test import override_settings
+except ImportError:
+    # TODO: Remove Django 1.6 compatibility after move to Django 1.9
+    from django.test.utils import override_settings
+
+__author__ = 'joe'
+
+fake_s3 = FakeS3()
+
+
+@mock.patch('ide.models.files.s3', fake_s3)
+class TestsSource(CloudpebbleTestCase):
+    """Tests for the Tests models"""
+
+    def setUp(self):
+        self.login()
+
+    def create_file(self, name='file.c', content=None, target=None, success=True):
+        """ Create a source file """
+        url = reverse('ide:create_source_file', args=[self.project_id])
+        data = {}
+        if name is not None:
+            data['name'] = name
+        if content is not None:
+            data['content'] = content
+        if target is not None:
+            data['target'] = target
+        result = json.loads(self.client.post(url, data).content)
+        self.assertEqual(result['success'], success)
+        if success:
+            self.assertEqual(result['file']['name'], name)
+            self.assertEqual(result['file']['target'], target if target else 'app')
+        return result['file']
+
+    def load_file(self, id, success=True):
+        """ Load a source file's content """
+        url = reverse('ide:load_source_file', args=[self.project_id, id])
+        result = json.loads(self.client.get(url).content)
+        self.assertEqual(result['success'], success)
+        return result
+
+    def rename_file(self, id, modified, old_name=None, new_name=None, success=True):
+        """ Rename a source file """
+        url = reverse('ide:rename_source_file', args=[self.project_id, id])
+        data = {}
+        if old_name is not None:
+            data['old_name'] = old_name
+        if new_name is not None:
+            data['new_name'] = new_name
+        if modified is not None:
+            data['modified'] = modified
+        result = json.loads(self.client.post(url, data).content)
+        self.assertEqual(result['success'], success)
+        return result
+
+    def save_file(self, id, modified, content=None, folded_lines='[]', success=True):
+        """ Save new content to a source file """
+        data = {}
+        if content is not None:
+            data['content'] = content
+        if folded_lines is not None:
+            data['folded_lines'] = folded_lines
+        if modified is not None:
+            data['modified'] = modified
+        url = reverse('ide:save_source_file', args=[self.project_id, id])
+        result = json.loads(self.client.post(url, data).content)
+        self.assertEqual(result['success'], success)
+
+        return result
+
+    def get_source_names(self):
+        """ Get a list of project source file names """
+        project = json.loads(self.client.get(reverse('ide:project_info', args=[self.project_id])).content)
+        return {x['name'] for x in project['source_files']}
+
+    def test_create(self):
+        """ Test creating files in various valid states """
+        self.create_file("c_file.c")
+        self.create_file("js_file.js")
+        self.create_file("with_content.c", content="blah" * 100)
+        self.create_file("without_content.c", content=None)
+        self.create_file("worker.c", target='worker')
+
+    def test_create_load_save(self):
+        """ Test a full sequence of creating, loading, saving and re-loading a file"""
+        content = " Hello world ^^ "
+        new_content = "New content"
+        info = self.create_file(content=content)
+        loaded = self.load_file(info['id'])
+        self.assertEqual(content, loaded['source'])
+        self.save_file(info['id'], int(loaded['modified']), content=new_content)
+        loaded = self.load_file(info['id'])
+        self.assertEqual(new_content, loaded['source'])
+
+
+    def test_create_with_invalid_target_throws_error(self):
+        """ Test that attempting to create a file with an invalid target throws an error """
+        with self.assertRaises(ValidationError):
+            self.create_file(target='invalid')
+
+    def test_create_with_invalid_names_throws_error(self):
+        """ Check that attempts to create files with invalid names throw errors """
+        with self.assertRaises(MultiValueDictKeyError):
+            self.create_file(name=None)
+        with self.assertRaises(ValidationError):
+            self.create_file("no_extension")
+        with self.assertRaises(ValidationError):
+            self.create_file("bad_extension.html")
+        with self.assertRaises(ValidationError):
+            self.create_file(".c")
+        with self.assertRaises(ValidationError):
+            self.create_file("`unsafe characters`.c")
+
+    def test_rename(self):
+        """ Check that files can be renamed """
+        name1 = "name1.c"
+        name2 = "name2.c"
+        info = self.create_file(name1)
+        loaded = self.load_file(info['id'])
+        self.rename_file(info['id'], int(loaded['modified']), name1, name2)
+        self.assertIn(name2, self.get_source_names())
+
+    def test_rename_outdated_file_fails(self):
+        """ Check that a file which was modified externally fails to rename """
+        name1 = "name1.c"
+        name2 = "name2.c"
+        info = self.create_file(name1)
+        loaded = self.load_file(info['id'])
+        self.rename_file(info['id'], int(loaded['modified']-5000), name1, name2, success=False)
+        self.assertIn(name1, self.get_source_names())

--- a/ide/utils/cloudpebble_test.py
+++ b/ide/utils/cloudpebble_test.py
@@ -1,0 +1,21 @@
+import json
+
+from django.test import TestCase
+from django.test.client import Client
+from django.test.utils import setup_test_environment
+
+setup_test_environment()
+
+# TODO: after moving to Django 1.9, use client.post().json() instead of json.loads(client.post().content)
+
+class CloudpebbleTestCase(TestCase):
+    """CloudpebbleTestCase provides convenience functions for other test cases"""
+
+    def login(self):
+        self.client = Client()
+        self.client.post('/accounts/register', {'username': 'test', 'email': 'test@test.test', 'password1': 'test', 'password2': 'test'})
+        login_result = self.client.login(username='test', password='test')
+        self.assertTrue(login_result)
+        new_project = json.loads(self.client.post('/ide/project/create', {'name': 'test', 'template': 0, 'type': 'native', 'sdk': 3}).content)
+        self.assertTrue(new_project['success'])
+        self.project_id = new_project['id']

--- a/ide/utils/cloudpebble_test.py
+++ b/ide/utils/cloudpebble_test.py
@@ -3,19 +3,28 @@ import json
 from django.test import TestCase
 from django.test.client import Client
 from django.test.utils import setup_test_environment
+try:
+    from django.test import override_settings
+except ImportError:
+    from django.test.utils import override_settings
 
 setup_test_environment()
+
 
 # TODO: after moving to Django 1.9, use client.post().json() instead of json.loads(client.post().content)
 
 class CloudpebbleTestCase(TestCase):
     """CloudpebbleTestCase provides convenience functions for other test cases"""
 
-    def login(self):
+    def login(self, project_options=None):
         self.client = Client()
         self.client.post('/accounts/register', {'username': 'test', 'email': 'test@test.test', 'password1': 'test', 'password2': 'test'})
         login_result = self.client.login(username='test', password='test')
         self.assertTrue(login_result)
-        new_project = json.loads(self.client.post('/ide/project/create', {'name': 'test', 'template': 0, 'type': 'native', 'sdk': 3}).content)
+        create_data = {'name': 'test', 'template': 0, 'type': 'native', 'sdk': 3}
+        if project_options:
+            create_data.update(project_options)
+        new_project = json.loads(self.client.post('/ide/project/create', create_data).content)
         self.assertTrue(new_project['success'])
         self.project_id = new_project['id']
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ psycogreen==1.0
 requests==2.7.0
 oauth2client==1.3
 django-bower==5.0.4
-
+mock==2.0.0
 # This is used for Mailchimp integration
 mailchimp==2.0.9
 

--- a/utils/fakes.py
+++ b/utils/fakes.py
@@ -18,12 +18,14 @@ class FakeS3(object):
     """ Essentially just a dictionary where the keys are tuples of (bucket_name, path) """
     def __init__(self):
         self.dict = {}
+        self.last_key = None
 
     def read_file(self, bucket_name, path):
         return self.dict[(bucket_name, path)]
 
     def save_file(self, bucket_name, path, value, **kwargs):
         self.dict[(bucket_name, path)] = value
+        self.last_key = (bucket_name, path)
 
     def delete_file(self, bucket_name, path):
         del self.dict[(bucket_name, path)]

--- a/utils/fakes.py
+++ b/utils/fakes.py
@@ -1,0 +1,37 @@
+class FakeRedis(object):
+    """ Essentially just a dictionary accessed via 'get' and 'set' methods """
+
+    def __init__(self):
+        self.storage = {}
+        self.ex = None
+
+    def set(self, key, value, ex=0):
+        self.storage[key] = str(value)
+        self.ex = ex
+
+    def get(self, key, ex=0):
+        self.ex = ex
+        return self.storage.get(key, None)
+
+
+class FakeS3(object):
+    """ Essentially just a dictionary where the keys are tuples of (bucket_name, path) """
+    def __init__(self):
+        self.dict = {}
+
+    def read_file(self, bucket_name, path):
+        return self.dict[(bucket_name, path)]
+
+    def save_file(self, bucket_name, path, value, **kwargs):
+        self.dict[(bucket_name, path)] = value
+
+    def delete_file(self, bucket_name, path):
+        del self.dict[(bucket_name, path)]
+
+    def read_file_to_filesystem(self, bucket_name, path, destination):
+        with open(destination, 'w') as f:
+            f.write(self.read_file(bucket_name, path))
+
+    def upload_file(self, bucket_name, path, src_path, **kwargs):
+        with open(src_path, 'r') as f:
+            self.save_file(bucket_name, path, f.read())

--- a/utils/fakes.py
+++ b/utils/fakes.py
@@ -31,9 +31,7 @@ class FakeS3(object):
         del self.dict[(bucket_name, path)]
 
     def read_file_to_filesystem(self, bucket_name, path, destination):
-        with open(destination, 'w') as f:
-            f.write(self.read_file(bucket_name, path))
+        raise NotImplementedError("S3 Filesystem operations are not allowed during tests")
 
     def upload_file(self, bucket_name, path, src_path, **kwargs):
-        with open(src_path, 'r') as f:
-            self.save_file(bucket_name, path, f.read())
+        raise NotImplementedError("S3 Filesystem operations are not allowed during tests")


### PR DESCRIPTION
This is an enabling PR for test-bench, which sets up Travis and adds a number of tests and some test helper code.

- The `CloudpebbleTestCase` is a convenience subclass of TestCase which provides a function for logging in and creating a project
- `FakeS3` and `FakeRedis` are in-memory fakes which can be used to avoid touching real services.
- Also included is a simple suite of tests for testing source file APIs

(Dependant on #308 )