### PR TITLE
Add 'require' to jshint_globals for mutlijs

### DIFF
--- a/ide/static/ide/js/editor.js
+++ b/ide/static/ide/js/editor.js
@@ -304,6 +304,10 @@ CloudPebble.Editor = (function() {
                                 require: true,
                                 ajax: true
                             });
+                        } else if (CloudPebble.ProjectInfo.app_modern_multi_js) {
+                            _.extend(jshint_globals, {
+                                require: true
+                            });
                         }
 
                         var success = JSHINT(code_mirror.getValue(), {


### PR DESCRIPTION
This adds 'require' to the jshint globals for CommonJS projects. There will remain a bug where a user can change whether the app uses CommonJS-style and code hinting will become incorrect for already opened files, but probably won't be a common issue.