### PR TITLE
Added an S3 BucketHolder

### DIFF
--- a/cloudpebble/settings.py
+++ b/cloudpebble/settings.py
@@ -309,6 +309,7 @@ AWS_SECRET_ACCESS_KEY = _environ.get('AWS_SECRET_ACCESS_KEY', None)
 AWS_S3_SOURCE_BUCKET = _environ.get('AWS_S3_SOURCE_BUCKET', 'source.cloudpebble.net')
 AWS_S3_BUILDS_BUCKET = _environ.get('AWS_S3_BUILDS_BUCKET', 'builds.cloudpebble.net')
 AWS_S3_EXPORT_BUCKET = _environ.get('AWS_S3_EXPORT_BUCKET', 'export.cloudpebble.net')
+AWS_S3_HOST = _environ.get('AWS_S3_HOST', None)
 AWS_S3_FAKE_S3 = _environ.get('AWS_S3_FAKE_S3', None)
 
 TYPOGRAPHY_CSS = _environ.get('TYPOGRAPHY_CSS', None)

--- a/cloudpebble/settings.py
+++ b/cloudpebble/settings.py
@@ -1,12 +1,15 @@
 # encoding: utf-8
 # Django settings for cloudpebble project.
 
+import sys
 import os
 import socket
 import dj_database_url
+
 _environ = os.environ
 
 DEBUG = _environ.get('DEBUG', '') != ''
+TESTING = 'test' in sys.argv
 TEMPLATE_DEBUG = DEBUG
 
 ADMINS = (

--- a/utils/s3.py
+++ b/utils/s3.py
@@ -57,6 +57,8 @@ class BucketHolder(object):
             self.buckets = None
 
     def __getitem__(self, item):
+        if settings.TESTING:
+            raise Exception("S3 not mocked in test!")
         if not self.configured:
             self.configure()
         return self.buckets[item]

--- a/utils/s3.py
+++ b/utils/s3.py
@@ -1,8 +1,9 @@
 import boto
 from boto.s3.key import Key
-from boto.s3.connection import OrdinaryCallingFormat
+from boto.s3.connection import OrdinaryCallingFormat, NoHostProvided
 from django.conf import settings
 import urllib
+
 
 def _ensure_bucket_exists(s3, bucket):
     try:
@@ -12,26 +13,56 @@ def _ensure_bucket_exists(s3, bucket):
     else:
         print "Created bucket %s" % bucket
 
-if settings.AWS_ENABLED:
-    if settings.AWS_S3_FAKE_S3 is None:
-        _s3 = boto.connect_s3(settings.AWS_ACCESS_KEY_ID, settings.AWS_SECRET_ACCESS_KEY)
-    else:
-        host, port = (settings.AWS_S3_FAKE_S3.split(':', 2) + [80])[:2]
-        port = int(port)
-        _s3 = boto.connect_s3("key_id", "secret_key", is_secure=False, port=port,
-                              host=host, calling_format=OrdinaryCallingFormat())
-        _ensure_bucket_exists(_s3, settings.AWS_S3_SOURCE_BUCKET)
-        _ensure_bucket_exists(_s3, settings.AWS_S3_EXPORT_BUCKET)
-        _ensure_bucket_exists(_s3, settings.AWS_S3_BUILDS_BUCKET)
 
-    _buckets = {
-        'source': _s3.get_bucket(settings.AWS_S3_SOURCE_BUCKET),
-        'export': _s3.get_bucket(settings.AWS_S3_EXPORT_BUCKET),
-        'builds': _s3.get_bucket(settings.AWS_S3_BUILDS_BUCKET),
-    }
-else:
-    _s3 = None
-    _buckets = None
+class BucketHolder(object):
+    """ The bucket holder configures s3 when it is first accessed. This cannot be done on module import due to quirks in Django's settings system.
+    See: https://docs.djangoproject.com/en/dev/internals/contributing/writing-code/coding-style/#use-of-django-conf-settings """
+
+    def __init__(self):
+        self.buckets = {}
+        self.configured = False
+        self.s3 = None
+
+    def configure(self):
+        if settings.AWS_ENABLED:
+            if settings.AWS_S3_FAKE_S3 is None:
+                # The host must be manually specified in Python 2.7.9+ due to
+                # https://github.com/boto/boto/issues/2836 this bug in boto with .s in
+                # bucket names.
+                host = settings.AWS_S3_HOST if settings.AWS_S3_HOST else NoHostProvided
+
+                self.s3 = boto.connect_s3(
+                    settings.AWS_ACCESS_KEY_ID,
+                    settings.AWS_SECRET_ACCESS_KEY,
+                    host=host,
+                    calling_format=OrdinaryCallingFormat()
+                )
+            else:
+                host, port = (settings.AWS_S3_FAKE_S3.split(':', 2) + [80])[:2]
+                port = int(port)
+                self.s3 = boto.connect_s3("key_id", "secret_key", is_secure=False, port=port,
+                                          host=host, calling_format=OrdinaryCallingFormat())
+                _ensure_bucket_exists(self.s3, settings.AWS_S3_SOURCE_BUCKET)
+                _ensure_bucket_exists(self.s3, settings.AWS_S3_EXPORT_BUCKET)
+                _ensure_bucket_exists(self.s3, settings.AWS_S3_BUILDS_BUCKET)
+
+            self.buckets = {
+                'source': self.s3.get_bucket(settings.AWS_S3_SOURCE_BUCKET),
+                'export': self.s3.get_bucket(settings.AWS_S3_EXPORT_BUCKET),
+                'builds': self.s3.get_bucket(settings.AWS_S3_BUILDS_BUCKET),
+            }
+            self.configured = True
+        else:
+            self.s3 = None
+            self.buckets = None
+
+    def __getitem__(self, item):
+        if not self.configured:
+            self.configure()
+        return self.buckets[item]
+
+
+_buckets = BucketHolder()
 
 
 def _requires_aws(fn):
@@ -40,6 +71,7 @@ def _requires_aws(fn):
     else:
         def complain(*args, **kwargs):
             raise Exception("AWS_ENABLED must be True to call %s" % fn.__name__)
+
         return complain
 
 
@@ -56,11 +88,13 @@ def read_file_to_filesystem(bucket_name, path, destination):
     key = bucket.get_key(path)
     key.get_contents_to_filename(destination)
 
+
 @_requires_aws
 def delete_file(bucket_name, path):
     bucket = _buckets[bucket_name]
     key = bucket.get_key(path)
     key.delete()
+
 
 @_requires_aws
 def save_file(bucket_name, path, value, public=False, content_type='application/octet-stream'):
@@ -92,7 +126,7 @@ def upload_file(bucket_name, dest_path, src_path, public=False, content_type='ap
     }
 
     if download_filename is not None:
-        headers['Content-Disposition'] = 'attachment;filename="%s"' % download_filename.replace(' ','_')
+        headers['Content-Disposition'] = 'attachment;filename="%s"' % download_filename.replace(' ', '_')
 
     key.set_contents_from_filename(src_path, policy=policy, headers=headers)
 


### PR DESCRIPTION
`s3.py` currently does two bad things:

1. Access settings in the top level, which [isn't really allowed](https://docs.djangoproject.com/en/dev/internals/contributing/writing-code/coding-style/#use-of-django-conf-settings) and caused me enough problems to motivate this change.
2. Attempts to connect to S3 immediately, which is a needless overhead when running `./manage.py test` and also causes some other problems.

The solution presented here is a singleton which is initialised the first time that S3 is accessed. The changes also includes the fixes needed for Python 2.7.11.