### PR TITLE
Prevent SDK 3 to 2 transition in UI

### DIFF
--- a/ide/templates/ide/project/settings.html
+++ b/ide/templates/ide/project/settings.html
@@ -14,7 +14,7 @@
                 <label class="control-label" for="settings-sdk-version">{% trans "SDK Version" %}</label>
                 <div class="controls">
                     <select id="settings-sdk-version">
-                        <option value="2" {% if project.sdk_version == '2' %}selected{% endif %}>{% trans 'SDK 2 (Pebble, Pebble Steel)' %}</option>
+                        <option value="2" {% if project.sdk_version == '2' %}selected{% else %}disabled{% endif %}>{% trans 'SDK 2 (Pebble, Pebble Steel)' %}</option>
                         <option value="3" {% if project.sdk_version == '3' %}selected{% endif %}>{% trans 'SDK 3 (Pebble Time)' %}</option>
                     </select>
                     <span class="help-block">You should reload the page after changing and saving this setting.</span>


### PR DESCRIPTION
This disables the option in the project settings UI to switch a non SDK-2 project to SDK 2.