### PR TITLE
Missing script tag in gist-import.html

### DIFF
--- a/ide/templates/ide/gist-import.html
+++ b/ide/templates/ide/gist-import.html
@@ -17,4 +17,5 @@ var GIST_ID = "{{ gist_id | escapejs }}";
 </script>
 <script src="{% static 'ide/js/csrf.js' %}" type="text/javascript"></script>
 <script src="{% static 'ide/js/gist_import.js' %}" type="text/javascript"></script>
+<script src="/ide/jsi18n/"></script>
 {% endblock %}


### PR DESCRIPTION
gist-import.html is missing the `interpolate` function, which means that no error message is displayed if the import fails. This PR adds the reference in.