### PR TITLE
Fix apps not building when short name is not a valid npm package name

### DIFF
--- a/ide/tests/test_manifest_generation.py
+++ b/ide/tests/test_manifest_generation.py
@@ -7,10 +7,6 @@ from ide.models import Project, Dependency
 
 
 class ManifestTester(CloudpebbleTestCase):
-    def setUp(self):
-        self.login()
-        self.project = Project.objects.get(pk=self.project_id)
-
     def check_package_manifest(self, manifest, package_options=None, pebble_options=None):
         """ Check that a generated manifest file looks like a manually assembled manifest file
         :param manifest: Manifest to check
@@ -63,6 +59,12 @@ class TestNPMStyleManifestGeneration(ManifestTester):
         self.project.keywords = keywords
         manifest = generate_manifest(self.project, [])
         self.check_package_manifest(manifest, package_options={'keywords': keywords})
+
+    def test_manifest_short_name(self):
+        """ Check that app_short_name is mangled into a valid npm package name """
+        self.project.app_short_name = "_CAPITALS_and...dots-and  -  spaces ! "
+        manifest = generate_manifest(self.project, [])
+        self.check_package_manifest(manifest, package_options={'name': 'capitals_and...dots-and-spaces'})
 
 
 @override_settings(NPM_MANIFEST_SUPPORT='')

--- a/ide/utils/sdk.py
+++ b/ide/utils/sdk.py
@@ -325,9 +325,21 @@ def generate_v3_manifest_dict(project, resources):
         return manifest
 
 
+def make_valid_package_manifest_name(short_name):
+    """ Turn an app_short_name into a valid NPM package name. """
+    name = short_name.lower()
+    # Remove any invalid characters from the end
+    name = re.sub(r'[^a-z0-9._]+$', '', name)
+    # Any strings of invalid characters in the middle are converted to dashes
+    name = re.sub(r'[^a-z0-9._]+', '-', name)
+    # The name cannot start with [ ._] or end with spaces.
+    name = name.lstrip(' ._').rstrip()
+    return name
+
+
 def generate_package_manifest_dict(project, resources):
     manifest = {
-        'name': project.app_short_name,
+        'name': make_valid_package_manifest_name(project.app_short_name),
         'author': project.app_company_name,
         'version': project.semver,
         'keywords': project.keywords,


### PR DESCRIPTION
This adds a function to mangle short names so that they are valid NPM package names.