### PR TITLE
Fixed gist import links

### DIFF
--- a/ide/static/ide/js/gist_import.js
+++ b/ide/static/ide/js/gist_import.js
@@ -17,7 +17,7 @@ $(function() {
         return Ajax.Post('/ide/import/gist', {gist_id: gist_id}).then(function(data) {
             return Ajax.PollTask(data.task_id, {milliseconds: 500});
         }).then(function(result) {
-            return 'ide/project/' + result;
+            return '/ide/project/' + result;
         });
     };
 });


### PR DESCRIPTION
A missing forward slash caused gist imports to redirect to `/ide/gist/ide/project/<number>` whereas it should be `ide/project/<number>`. This corrects that regression.