### PR TITLE
Factor out NPM_MANIFEST_SUPPORT flag

### DIFF
--- a/cloudpebble/settings.py
+++ b/cloudpebble/settings.py
@@ -331,7 +331,6 @@ GITHUB_HOOK_TEMPLATE = _environ.get('GITHUB_HOOK', 'http://example.com/ide/proje
 SDK2_PEBBLE_WAF = _environ.get('SDK2_PEBBLE_WAF', '/sdk2/pebble/waf')
 SDK3_PEBBLE_WAF = _environ.get('SDK3_PEBBLE_WAF', '/sdk3/pebble/waf')
 
-NPM_MANIFEST_SUPPORT = _environ.get('NPM_MANIFEST_SUPPORT', '') != ''
 NPM_BINARY = _environ.get('NPM_BINARY', 'npm')
 
 ARM_CS_TOOLS = _environ.get('ARM_CS_TOOLS', '/arm-cs-tools/bin/')

--- a/ide/api/project.py
+++ b/ide/api/project.py
@@ -188,7 +188,7 @@ def create_project(request):
             elif project_type == 'pebblejs':
                 f = SourceFile.objects.create(project=project, file_name="app.js")
                 f.save_text(open('{}/src/js/app.js'.format(settings.PEBBLEJS_ROOT)).read())
-            if settings.NPM_MANIFEST_SUPPORT and sdk_version != '2':
+            if sdk_version != '2':
                 project.app_keys = '[]'
             project.save()
     except IntegrityError as e:

--- a/ide/tasks/gist.py
+++ b/ide/tasks/gist.py
@@ -64,8 +64,7 @@ def import_gist(user_id, gist_id):
         package['pebble'] = defaultdict(lambda: None)
         package['pebble'].update(content.get('pebble', {}))
         manifest_settings, media, dependencies = load_manifest_dict(package, PACKAGE_MANIFEST, default_project_type=None)
-        if settings.NPM_MANIFEST_SUPPORT:
-            default_settings['app_keys'] = '[]'
+        default_settings['app_keys'] = '[]'
     elif APPINFO_MANIFEST in files:
         content = json.loads(files['appinfo.json'].content)
         package = defaultdict(lambda: None)

--- a/ide/templates/ide/project.html
+++ b/ide/templates/ide/project.html
@@ -65,7 +65,7 @@
                     <li class="nav-header" id="sidebar-pane-settings"><a href="#">{% trans 'Settings' %}</a></li>
                     <li class="nav-header sdk3-only" id="sidebar-pane-timeline"><a href="#">Timeline (Preview)</a></li>
                     <li class="nav-header" id="sidebar-pane-compile"><a href="#">{% trans 'Compilation' %}</a></li>
-                    {% if npm_manifest_support_enabled and project.project_type != 'pebblejs' %}
+                    {% if project.project_type != 'pebblejs' %}
                         <li class="nav-header sdk3-only" id="sidebar-pane-dependencies"><a href="#">{% trans 'Dependencies' %}</a></li>
                     {% endif %}
                     <li id="sidebar-pane-github" class="nav-header {%if not project.owner.github%}disabled{%endif%}"><a href="#">GitHub</a></li>

--- a/ide/templates/ide/project/settings.html
+++ b/ide/templates/ide/project/settings.html
@@ -152,7 +152,6 @@
                 </div>
             </div>
             <div class="well">
-                {% if npm_manifest_support_enabled %}
                 <div class="control-group native-only sdk3-only">
                     <label class="control-label" for="settings-message-key-kind">{% trans 'Message key assignment kind' %}</label>
                     <div class="controls">
@@ -162,7 +161,6 @@
                         </select>
                     </div>
                 </div>
-                {% endif %}
                 <div class="control-group native-only">
                     <label class="control-label" for="settings-app-keys">{% trans "PebbleKit JS Message Keys" %}</label>
                     <div class="controls">

--- a/ide/tests/test_compile.py
+++ b/ide/tests/test_compile.py
@@ -58,30 +58,21 @@ class TestCompile(CloudpebbleTestCase):
         self.assertEqual(self.build_result.state, BuildResult.STATE_SUCCEEDED)
         self.assertSequenceEqual([size.binary_size > 0 for size in self.build_result.sizes.all()], [True]*num_platforms)
 
-    def test_native_SDK2_project_with_appinfo(self):
+    def test_native_SDK2_project(self):
         """ Check that an SDK 3 project (with package.json support off) builds successfully """
         self.make_project({'sdk': '2'})
         self.add_file("main.c", SIMPLE_MAIN)
         self.compile()
         self.check_success(num_platforms=1)
 
-    @override_settings(NPM_MANIFEST_SUPPORT='')
-    def test_native_SDK3_project_with_appinfo(self):
-        """ Check that an SDK 3 project (with package.json support off) builds successfully """
-        self.make_project()
-        self.add_file("main.c", SIMPLE_MAIN)
-        self.compile()
-        self.check_success()
-
-    @override_settings(NPM_MANIFEST_SUPPORT='yes')
-    def test_native_SDK3_simple_project_with_NPM_manifest(self):
+    def test_native_SDK3_project(self):
         """ Check that an SDK 3 project (with package.json support on) builds successfully """
         self.make_project()
         self.add_file("main.c", SIMPLE_MAIN)
         self.compile()
         self.check_success()
 
-    @override_settings(NPM_MANIFEST_SUPPORT='yes', LOCAL_DEPENDENCY_OVERRIDE=True)
+    @override_settings(LOCAL_DEPENDENCY_OVERRIDE=True)
     def test_project_with_dependencies(self):
         """ Check that an SDK 3 project with dependencies builds successfully """
         self.make_project()

--- a/ide/tests/test_create_archive.py
+++ b/ide/tests/test_create_archive.py
@@ -24,23 +24,9 @@ class ExportTester(CloudpebbleTestCase):
         self.assertSetEqual(filenames, expected_filenames)
 
 
-@override_settings(NPM_MANIFEST_SUPPORT='')
 @mock.patch('ide.tasks.archive.s3', fake_s3)
 @mock.patch('ide.models.s3file.s3', fake_s3)
-class TestExportWithoutNPMSupport(ExportTester):
-    def test_export_sdk_3_project(self):
-        """ With package.json support off, check that SDK3 projects are exported with appinfo.json files """
-        self.run_test({'test/src/main.c', 'test/appinfo.json', 'test/wscript', 'test/jshintrc'})
-
-    def test_export_sdk_2_project(self):
-        """ Check that SDK2 projects are exported with appinfo.json files """
-        self.run_test({'test/src/main.c', 'test/appinfo.json', 'test/wscript', 'test/jshintrc'}, {'sdk': '2'})
-
-
-@override_settings(NPM_MANIFEST_SUPPORT='yes')
-@mock.patch('ide.tasks.archive.s3', fake_s3)
-@mock.patch('ide.models.s3file.s3', fake_s3)
-class TestExportWithNPMSupport(ExportTester):
+class TestExport(ExportTester):
     def test_export_sdk_3_project(self):
         """ With package.json support off, check that SDK3 projects are exported with package.json files """
         self.run_test({'test/src/main.c', 'test/package.json', 'test/wscript', 'test/jshintrc'})

--- a/ide/tests/test_import_archive.py
+++ b/ide/tests/test_import_archive.py
@@ -141,13 +141,3 @@ class TestImportProject(CloudpebbleTestCase):
         })
         with self.assertRaises(ValidationError):
             do_import_archive(self.project_id, bundle)
-
-    @override_settings(NPM_MANIFEST_SUPPORT='')
-    def test_throws_if_importing_array_appkeys_without_npm_manifest_support(self):
-        """ Throw when trying to import a project with auto-assigned messageKeys before NPM manifest support is fully enabled """
-        bundle = build_bundle({
-            'src/main.c': '',
-            'package.json': make_package(pebble_options={'messageKeys': []})
-        })
-        with self.assertRaises(InvalidProjectArchiveException):
-            do_import_archive(self.project_id, bundle)

--- a/ide/tests/test_import_export.py
+++ b/ide/tests/test_import_export.py
@@ -51,20 +51,12 @@ class TestImportExport(CloudpebbleTestCase):
         exported_manifest = read_bundle(fake_s3.read_last_file())[expected_export_package_filename]
         self.assertDictEqual(json.loads(expected_manifest), json.loads(exported_manifest))
 
-    @override_settings(NPM_MANIFEST_SUPPORT='yes')
     def test_import_then_export_npm_style(self):
         """ An imported then exported project manifest should remain identical, preserving all important data. """
         manifest, _ = self.make_custom_manifests(messageKeys={'key': 1, 'keytars': 2})
         self.runTest(manifest, 'package.json', 'test/package.json')
 
-    @override_settings(NPM_MANIFEST_SUPPORT='yes')
     def test_import_then_export_npm_style_with_new_messageKeys(self):
         """ We should be able to import and export SDK 3 projects with arrays for messageKeys """
         manifest, _ = self.make_custom_manifests(messageKeys=['keyLimePie', 'donkey[123]'])
         self.runTest(manifest, 'package.json', 'test/package.json')
-
-    @override_settings(NPM_MANIFEST_SUPPORT='')
-    def test_import_npm_then_export_appifo(self):
-        """ With NPM export support off, an imported package.json project should export with an appinfo.json """
-        npm_manifest, appinfo_manifest = self.make_custom_manifests(messageKeys={'key': 1, 'keytars': 2})
-        self.runTest(npm_manifest, 'package.json', 'test/appinfo.json', expected_manifest=appinfo_manifest)

--- a/ide/tests/test_manifest_generation.py
+++ b/ide/tests/test_manifest_generation.py
@@ -29,7 +29,6 @@ class ManifestTester(CloudpebbleTestCase):
         self.assertDictEqual(json.loads(manifest), json.loads(compare_to))
 
 
-@override_settings(NPM_MANIFEST_SUPPORT='yes')
 class TestNPMStyleManifestGeneration(ManifestTester):
     """ Test an SDK 3 project with package.json support ON"""
 
@@ -65,17 +64,3 @@ class TestNPMStyleManifestGeneration(ManifestTester):
         self.project.app_short_name = "_CAPITALS_and...dots-and  -  spaces ! "
         manifest = generate_manifest(self.project, [])
         self.check_package_manifest(manifest, package_options={'name': 'capitals_and...dots-and-spaces'})
-
-
-@override_settings(NPM_MANIFEST_SUPPORT='')
-class TestSDK3ManifestGeneration(ManifestTester):
-    """ Test an SDK 3 project with package.json support OFF"""
-
-    def setUp(self):
-        self.login()
-        self.project = Project.objects.get(pk=self.project_id)
-
-    def test_package_manifest(self):
-        """ Check that the appinfo.json file generated from a project is functionally identical to a generated sample manifest. """
-        manifest = generate_manifest(self.project, [])
-        self.check_appinfo_manifest(manifest)

--- a/ide/utils/cloudpebble_test.py
+++ b/ide/utils/cloudpebble_test.py
@@ -81,7 +81,7 @@ def make_package(package_options=None, pebble_options=None, no_pebble=False):
         "keywords": [],
         "name": "test",
         "pebble": {
-            "messageKeys": ([] if settings.NPM_MANIFEST_SUPPORT else {}),
+            "messageKeys": [],
             "capabilities": [
                 ""
             ],

--- a/ide/utils/sdk.py
+++ b/ide/utils/sdk.py
@@ -1,7 +1,6 @@
 import json
 import re
 from django.utils.translation import ugettext as _
-from django.conf import settings
 from ide.utils.project import APPINFO_MANIFEST, PACKAGE_MANIFEST, InvalidProjectArchiveException
 
 __author__ = 'katharine'
@@ -255,7 +254,7 @@ def generate_jshint_file(project):
 
 
 def manifest_name_for_project(project):
-    if settings.NPM_MANIFEST_SUPPORT and project.project_type == 'native' and project.sdk_version == '3':
+    if project.project_type == 'native' and project.sdk_version == '3':
         return PACKAGE_MANIFEST
     else:
         return APPINFO_MANIFEST
@@ -283,10 +282,6 @@ def generate_v3_manifest(project, resources):
     return dict_to_pretty_json(generate_v3_manifest_dict(project, resources))
 
 
-def generate_package_manifest(project, resources):
-    return dict_to_pretty_json(generate_package_manifest_dict(project, resources))
-
-
 def generate_v2_manifest_dict(project, resources):
     manifest = {
         'uuid': str(project.app_uuid),
@@ -309,22 +304,6 @@ def generate_v2_manifest_dict(project, resources):
     return manifest
 
 
-def generate_v3_manifest_dict(project, resources):
-    if settings.NPM_MANIFEST_SUPPORT:
-        return generate_package_manifest_dict(project, resources)
-    else:
-        # Just extend the v2 one.
-        manifest = generate_v2_manifest_dict(project, resources)
-        manifest['enableMultiJS'] = project.app_modern_multi_js
-        if project.app_platforms:
-            manifest['targetPlatforms'] = project.app_platform_list
-        if project.app_is_hidden:
-            manifest['watchapp']['hiddenApp'] = project.app_is_hidden
-        manifest['sdkVersion'] = "3"
-        del manifest['versionCode']
-        return manifest
-
-
 def make_valid_package_manifest_name(short_name):
     """ Turn an app_short_name into a valid NPM package name. """
     name = short_name.lower()
@@ -337,7 +316,7 @@ def make_valid_package_manifest_name(short_name):
     return name
 
 
-def generate_package_manifest_dict(project, resources):
+def generate_v3_manifest_dict(project, resources):
     manifest = {
         'name': make_valid_package_manifest_name(project.app_short_name),
         'author': project.app_company_name,
@@ -565,12 +544,7 @@ def load_manifest_dict(manifest, manifest_kind, default_project_type='native'):
         project['app_company_name'] = manifest['author']
         project['semver'] = manifest['version']
         project['app_long_name'] = manifest['pebble']['displayName']
-        if settings.NPM_MANIFEST_SUPPORT:
-            project['app_keys'] = dict_to_pretty_json(manifest['pebble'].get('messageKeys', []))
-        else:
-            project['app_keys'] = dict_to_pretty_json(manifest['pebble'].get('messageKeys', {}))
-            if isinstance(json.loads(project['app_keys']), list):
-                raise InvalidProjectArchiveException("Auto-assigned (array) messageKeys are not yet supported.")
+        project['app_keys'] = dict_to_pretty_json(manifest['pebble'].get('messageKeys', []))
         project['keywords'] = manifest.get('keywords', [])
         dependencies = manifest.get('dependencies', {})
         manifest = manifest['pebble']

--- a/ide/views/project.py
+++ b/ide/views/project.py
@@ -49,8 +49,7 @@ def view_project(request, project_id):
         'token': token,
         'phone_shorturl': settings.PHONE_SHORTURL,
         'supported_platforms': supported_platforms,
-        'version_regex': SDK_VERSION_REGEX,
-        'npm_manifest_support_enabled': settings.NPM_MANIFEST_SUPPORT
+        'version_regex': SDK_VERSION_REGEX
     })
 
 


### PR DESCRIPTION
This removes the NPM_MANIFEST_SUPPORT flag by assuming it is always True. Additionally, all tests for behaviour when it was False have been deleted.