### PR TITLE
Fix logic error preventing github integration.

### DIFF
--- a/ide/tests/test_find_project_root.py
+++ b/ide/tests/test_find_project_root.py
@@ -103,3 +103,12 @@ class TestFindProjectRoot(TestCase):
             "src/main.c",
             "appinfo.json"
         ], "", "appinfo.json")
+
+    def test_PR_317(self):
+        """ PR 317 fixes a bug where find_project_root would fail with 11 character filenames """
+        self.run_test([
+            "MAINTAINERS",
+            "package.json",
+            "src/"
+            "src/main.c",
+        ], "", "package.json")

--- a/ide/utils/project.py
+++ b/ide/utils/project.py
@@ -56,6 +56,8 @@ def find_project_root_and_manifest(project_items):
         # Check if the file is one of the kinds of manifest file
         for name in MANIFEST_KINDS:
             dir_end = base_dir.rfind(name)
+            if dir_end == -1:
+                continue
             # Ensure that the file is actually a manifest file
             if dir_end + len(name) == len(base_dir):
                 if is_manifest(name, item.read()):


### PR DESCRIPTION
Use rindex() to find substring, and catch exception when not found.
rfind() returns -1, which screws up the math check for a match on
the following line, and eventually leads to invalid JSON execptions.