### PR TITLE
Support .json files

### DIFF
--- a/ide/static/ide/js/editor.js
+++ b/ide/static/ide/js/editor.js
@@ -67,10 +67,26 @@ CloudPebble.Editor = (function() {
 
         // Open it.
         return Ajax.Get('/ide/project/' + PROJECT_ID + '/source/' + file.id + '/load').then(function(data) {
-            var is_js = file.name.substr(-3) == '.js';
             var source = data.source;
             file.lastModified = data.modified;
             var pane = $('<div>');
+            var file_kind, file_mode;
+            if (/\.js$/.test(file.name)) {
+                file_kind = 'js';
+                file_mode = 'javascript';
+            }
+            else if (/\.json$/.test(file.name)) {
+                file_kind = 'json';
+                file_mode = 'application/json';
+            }
+            else {
+                file_kind = 'c';
+                file_mode = CloudPebble.Editor.PebbleMode;
+            }
+            function file_kind_in(options) {
+                return _.contains(options.split(' '), file_kind);
+            }
+            var language_has_autocomplete = (file_kind == 'c');
             var is_autocompleting = false;
             var settings = {
                 indentUnit: USER_SETTINGS.tab_width,
@@ -83,7 +99,7 @@ CloudPebble.Editor = (function() {
                 //highlightSelectionMatches: true,
                 smartIndent: true,
                 indentWithTabs: !USER_SETTINGS.use_spaces,
-                mode: (is_js ? 'javascript' : CloudPebble.Editor.PebbleMode),
+                mode: file_mode,
                 styleActiveLine: true,
                 value: source,
                 theme: USER_SETTINGS.theme,
@@ -93,10 +109,10 @@ CloudPebble.Editor = (function() {
                 settings.keyMap = USER_SETTINGS.keybinds;
             }
             if(!settings.extraKeys) settings.extraKeys = {};
-            if(!is_js && USER_SETTINGS.autocomplete === 2) {
+            if(language_has_autocomplete && USER_SETTINGS.autocomplete === 2) {
                 settings.extraKeys = {'Ctrl-Space': 'autocomplete'};
             }
-            if(!is_js && USER_SETTINGS.autocomplete !== 0) {
+            if(language_has_autocomplete && USER_SETTINGS.autocomplete !== 0) {
                 settings.extraKeys['Tab'] = function() {
                     var marks = code_mirror.getAllMarks();
                     var cursor = code_mirror.getCursor();
@@ -186,10 +202,12 @@ CloudPebble.Editor = (function() {
             settings.extraKeys['Ctrl-/']  = function(cm) {
                 CodeMirror.commands.toggleComment(cm);
             };
-            if(is_js) {
-                settings.gutters = ['gutter-hint-warnings', 'CodeMirror-linenumbers', 'CodeMirror-foldgutter'];
-            } else {
-                settings.gutters = ['gutter-errors', 'CodeMirror-linenumbers', 'CodeMirror-foldgutter'];
+
+            settings.gutters = ['CodeMirror-linenumbers', 'CodeMirror-foldgutter'];
+            if(file_kind_in('js json')) {
+                settings.gutters.unshift('gutter-hint-warnings');
+            } else if (file_kind == 'c') {
+                settings.gutters.unshift('gutter-errors');
             }
             var code_mirror = CodeMirror(pane[0], settings);
             code_mirror.file_path = (file.target  == 'worker' ? 'worker_src/' : 'src/') + file.name;
@@ -234,16 +252,18 @@ CloudPebble.Editor = (function() {
                 create_popover(cm, token.string, pos.left, pos.top);
             };
 
-            if(!is_js && USER_SETTINGS.autocomplete === 1) {
+            if(language_has_autocomplete && USER_SETTINGS.autocomplete === 1) {
                 code_mirror.on('changes', function(instance, changes) {
                     update_patch_list(instance, changes);
                     if(!is_autocompleting)
                         CodeMirror.commands.autocomplete(code_mirror);
                 });
             }
-            if(is_js) {
+
+            if(file_kind_in('json js')) {
                 var warning_lines = [];
-                var throttled_hint = _.throttle(function() {
+                var do_hint = function() {
+                    var errors = [];
                     // Clear things out, even if jslint is off
                     // (the user might have just turned it off).
                     code_mirror.clearGutter('gutter-hint-warnings');
@@ -252,80 +272,101 @@ CloudPebble.Editor = (function() {
                     });
                     warning_lines = [];
 
-                    var jshint_globals = {
-                        Pebble: true,
-                        console: true,
-                        WebSocket: true,
-                        XMLHttpRequest: true,
-                        navigator: true, // For navigator.geolocation
-                        localStorage: true,
-                        setTimeout: true,
-                        setInterval: true,
-                        Int8Array: true,
-                        Uint8Array: true,
-                        Uint8ClampedArray: true,
-                        Int16Array: true,
-                        Uint16Array: true,
-                        Int32Array: true,
-                        Uint32Array: true,
-                        Float32Array: true,
-                        Float64Array: true
-                    };
-                    if(CloudPebble.ProjectInfo.type == 'simplyjs') {
-                        _.extend(jshint_globals, {
-                            simply: true,
-                            util2: true,
-                            ajax: true
-                        });
-                    } else if(CloudPebble.ProjectInfo.type == 'pebblejs') {
-                        _.extend(jshint_globals, {
-                            require: true,
-                            ajax: true
-                        });
-                    } else if (CloudPebble.ProjectInfo.app_modern_multi_js) {
-                        _.extend(jshint_globals, {
-                            require: true,
-                            exports: true,
-                            module: true
-                        });
+                    if (file_kind == 'js') {
+                        var jshint_globals = {
+                            Pebble: true,
+                            console: true,
+                            WebSocket: true,
+                            XMLHttpRequest: true,
+                            navigator: true, // For navigator.geolocation
+                            localStorage: true,
+                            setTimeout: true,
+                            setInterval: true,
+                            Int8Array: true,
+                            Uint8Array: true,
+                            Uint8ClampedArray: true,
+                            Int16Array: true,
+                            Uint16Array: true,
+                            Int32Array: true,
+                            Uint32Array: true,
+                            Float32Array: true,
+                            Float64Array: true
+                        };
+
+                        // Although you're not exactly supposed to parse JSON with jshint, it does
+                        // actually appear to go into a JSON mode when a file begins with {}.
+
+                        if (CloudPebble.ProjectInfo.type == 'simplyjs') {
+                            _.extend(jshint_globals, {
+                                simply: true,
+                                util2: true,
+                                ajax: true
+                            });
+                        } else if (CloudPebble.ProjectInfo.type == 'pebblejs') {
+                            _.extend(jshint_globals, {
+                                require: true,
+                                ajax: true
+                            });
+                        } else if (CloudPebble.ProjectInfo.app_modern_multi_js) {
+                            _.extend(jshint_globals, {
+                                require: true,
+                                exports: true,
+                                module: true
+                            });
+                        }
+
+
+                        var success = JSHINT(code_mirror.getValue(), {
+                            freeze: true,
+                            evil: false,
+                            immed: true,
+                            latedef: "nofunc",
+                            undef: true,
+                            unused: "vars"
+                        }, jshint_globals);
+                        if (!success) {
+                            errors = JSHINT.errors;
+                        }
+                    }
+                    else {
+                        var code = code_mirror.getValue();
+                        try {
+                            json_parse(code);
+                        }
+                        catch (e) {
+                            errors = [{
+                                reason: e.message,
+                                line: code.slice(0, e.at).split('\n').length
+                            }]
+                        }
                     }
 
-
-                    var success = JSHINT(code_mirror.getValue(), {
-                        freeze: true,
-                        evil: false,
-                        immed: true,
-                        latedef: "nofunc",
-                        undef: true,
-                        unused: "vars"
-                    }, jshint_globals);
-                    if(!success) {
-                        _.each(JSHINT.errors, function(error) {
-                            // It is apparently possible to get null errors; omit them.
-                            if(!error) return;
-                            // If there are multiple errors on one line, we'll have already placed a marker here.
-                            // Instead of replacing it with a new one, just update it.
-                            var markers = code_mirror.lineInfo(error.line - 1).gutterMarkers;
-                            if(markers && markers['gutter-hint-warnings']) {
-                                var marker = $(markers['gutter-hint-warnings']);
-                                marker.attr('title', marker.attr('title') + "\n" + error.reason);
-                            } else {
-                                var warning = $('<i class="icon-warning-sign icon-white"></span>');
-                                warning.attr('title', error.reason);
-                                code_mirror.setGutterMarker(error.line - 1, 'gutter-hint-warnings', warning[0]);
-                                warning_lines.push(code_mirror.addLineClass(error.line - 1, 'background', 'line-hint-warning'));
-                            }
-                        });
-                    }
-                }, 1000);
-
-                code_mirror.on('change', throttled_hint);
+                    _.each(errors, function(error) {
+                        // It is apparently possible to get null errors; omit them.
+                        if(!error) return;
+                        // If there are multiple errors on one line, we'll have already placed a marker here.
+                        // Instead of replacing it with a new one, just update it.
+                        var markers = code_mirror.lineInfo(error.line - 1).gutterMarkers;
+                        if(markers && markers['gutter-hint-warnings']) {
+                            var marker = $(markers['gutter-hint-warnings']);
+                            marker.attr('title', marker.attr('title') + "\n" + error.reason);
+                        } else {
+                            var warning = $('<i class="icon-warning-sign icon-white"></span>');
+                            warning.attr('title', error.reason);
+                            code_mirror.setGutterMarker(error.line - 1, 'gutter-hint-warnings', warning[0]);
+                            warning_lines.push(code_mirror.addLineClass(error.line - 1, 'background', 'line-hint-warning'));
+                        }
+                    });
+                };
+                code_mirror.on('change', _.debounce(do_hint, 1000));
                 // Make sure we're ready when we start.
-                throttled_hint();
-            } else {
+
+                do_hint();
+            }
+            if (file_kind == 'c') {
                 var clang_lines = [];
                 var sChecking = false;
-                var throttled_check = _.throttle(function() {
+                var throttled_check = _.debounce(function() {
                     if(sChecking) return;
                     sChecking = true;
                     CloudPebble.YCM.request('errors', code_mirror)
@@ -905,7 +946,8 @@ CloudPebble.Editor = (function() {
 
     function init_create_prompt() {
         var prompt = $('#editor-new-file-prompt');
-        prompt.find('#new-file-type').change(function() {
+        var file_type_picker = prompt.find('#new-file-type');
+        file_type_picker.change(function() {
             prompt.find('.file-group').hide();
             prompt.find('.' + $(this).val() + '-file-options').show();
             if($(this).val() == 'js') {
@@ -915,13 +957,16 @@ CloudPebble.Editor = (function() {
                 }
             }
         });
-        // If this isn't a native project, only JS files should exist.
+        // If this isn't a native project, only JS and JSON files should exist.
         if(CloudPebble.ProjectInfo.type != 'native') {
-            prompt.find('#new-file-type').val('js').change().parents('.control-group').hide();
+            file_type_picker.val('js').change();
+            file_type_picker.find('option').filter(function() {
+                return !(this.value == 'js' || this.value == 'json');
+            }).remove();
         }
 
         prompt.find('#editor-create-file-button').click(function() {
-            var kind = prompt.find('#new-file-type').val();
+            var kind = file_type_picker.val();
             var error = prompt.find('.alert');
             // do stuff.
             if(kind == 'c') {
@@ -968,6 +1013,22 @@ CloudPebble.Editor = (function() {
                     var name = prompt.find('#new-js-file-name').val();
                     if(!/.+\.js$/.test(name)) {
                         error.text(gettext("Source files must end in .js")).show();
+                    } else if(project_source_files[name]) {
+                        error.text(interpolate(gettext("A file called '%s' already exists."), [name])).show();
+                    } else {
+                        create_remote_file(name).then(function(data) {
+                            prompt.modal('hide');
+                            return edit_source_file(data.file);
+                        }).catch(function(err) {
+                            error.text(err.toString()).show();
+                        });
+                    }
+                })();
+            } else if(kind == 'json') {
+                (function() {
+                    var name = prompt.find('#new-json-file-name').val();
+                    if(!/.+\.json?$/.test(name)) {
+                        error.text(gettext("JSON files must end in .json")).show();
                     } else if(project_source_files[name]) {
                         error.text(interpolate(gettext("A file called '%s' already exists."), [name])).show();
                     } else {

--- a/ide/static/ide/js/editor.js
+++ b/ide/static/ide/js/editor.js
@@ -84,7 +84,7 @@ CloudPebble.Editor = (function() {
                 file_mode = CloudPebble.Editor.PebbleMode;
             }
             function file_kind_in(options) {
-                return _.contains(options.split(' '), file_kind);
+                return _.contains(options, file_kind);
             }
             var language_has_autocomplete = (file_kind == 'c');
             var is_autocompleting = false;
@@ -204,7 +204,7 @@ CloudPebble.Editor = (function() {
             };
 
             settings.gutters = ['CodeMirror-linenumbers', 'CodeMirror-foldgutter'];
-            if(file_kind_in('js json')) {
+            if(file_kind_in(['js', 'json'])) {
                 settings.gutters.unshift('gutter-hint-warnings');
             } else if (file_kind == 'c') {
                 settings.gutters.unshift('gutter-errors');
@@ -260,7 +260,7 @@ CloudPebble.Editor = (function() {
                 });
             }
 
-            if(file_kind_in('json js')) {
+            if(file_kind_in(['json', 'js'])) {
                 var warning_lines = [];
                 var do_hint = function() {
                     var errors = [];

--- a/ide/static/ide/js/editor.js
+++ b/ide/static/ide/js/editor.js
@@ -366,7 +366,7 @@ CloudPebble.Editor = (function() {
             if (file_kind == 'c') {
                 var clang_lines = [];
                 var sChecking = false;
-                var throttled_check = _.debounce(function() {
+                var debounced_check = _.debounce(function() {
                     if(sChecking) return;
                     sChecking = true;
                     CloudPebble.YCM.request('errors', code_mirror)
@@ -410,8 +410,8 @@ CloudPebble.Editor = (function() {
                             sChecking = false;
                         });
                 }, 2000);
-                code_mirror.on('change', throttled_check);
-                throttled_check();
+                code_mirror.on('change', debounced_check);
+                debounced_check();
 
                 code_mirror.on('mousedown', function(cm, e) {
                     if(e.ctrlKey || e.metaKey) {

--- a/ide/static/ide/js/json_parse.js
+++ b/ide/static/ide/js/json_parse.js
@@ -1,0 +1,356 @@
+/*
+    json_parse.js
+    2016-05-02
+
+    Public Domain.
+
+    NO WARRANTY EXPRESSED OR IMPLIED. USE AT YOUR OWN RISK.
+
+    This file creates a json_parse function.
+
+        json_parse(text, reviver)
+            This method parses a JSON text to produce an object or array.
+            It can throw a SyntaxError exception.
+
+            The optional reviver parameter is a function that can filter and
+            transform the results. It receives each of the keys and values,
+            and its return value is used instead of the original value.
+            If it returns what it received, then the structure is not modified.
+            If it returns undefined then the member is deleted.
+
+            Example:
+
+            // Parse the text. Values that look like ISO date strings will
+            // be converted to Date objects.
+
+            myData = json_parse(text, function (key, value) {
+                var a;
+                if (typeof value === "string") {
+                    a =
+/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2}(?:\.\d*)?)Z$/.exec(value);
+                    if (a) {
+                        return new Date(Date.UTC(+a[1], +a[2] - 1, +a[3], +a[4],
+                            +a[5], +a[6]));
+                    }
+                }
+                return value;
+            });
+
+    This is a reference implementation. You are free to copy, modify, or
+    redistribute.
+
+    This code should be minified before deployment.
+    See http://javascript.crockford.com/jsmin.html
+
+    USE YOUR OWN COPY. IT IS EXTREMELY UNWISE TO LOAD CODE FROM SERVERS YOU DO
+    NOT CONTROL.
+*/
+
+/*jslint for */
+
+/*property
+    at, b, call, charAt, f, fromCharCode, hasOwnProperty, message, n, name,
+    prototype, push, r, t, text
+*/
+
+var json_parse = (function () {
+    "use strict";
+
+// This is a function that can parse a JSON text, producing a JavaScript
+// data structure. It is a simple, recursive descent parser. It does not use
+// eval or regular expressions, so it can be used as a model for implementing
+// a JSON parser in other languages.
+
+// We are defining the function inside of another function to avoid creating
+// global variables.
+
+    var at;     // The index of the current character
+    var ch;     // The current character
+    var escapee = {
+        "\"": "\"",
+        "\\": "\\",
+        "/": "/",
+        b: "\b",
+        f: "\f",
+        n: "\n",
+        r: "\r",
+        t: "\t"
+    };
+    var text;
+
+    var error = function (m) {
+
+// Call error when something is wrong.
+
+        throw {
+            name: "SyntaxError",
+            message: m,
+            at: at,
+            text: text
+        };
+    };
+
+    var next = function (c) {
+
+// If a c parameter is provided, verify that it matches the current character.
+
+        if (c && c !== ch) {
+            error("Expected '" + c + "' instead of '" + ch + "'");
+        }
+
+// Get the next character. When there are no more characters,
+// return the empty string.
+
+        ch = text.charAt(at);
+        at += 1;
+        return ch;
+    };
+
+    var number = function () {
+
+// Parse a number value.
+
+        var value;
+        var string = "";
+
+        if (ch === "-") {
+            string = "-";
+            next("-");
+        }
+        while (ch >= "0" && ch <= "9") {
+            string += ch;
+            next();
+        }
+        if (ch === ".") {
+            string += ".";
+            while (next() && ch >= "0" && ch <= "9") {
+                string += ch;
+            }
+        }
+        if (ch === "e" || ch === "E") {
+            string += ch;
+            next();
+            if (ch === "-" || ch === "+") {
+                string += ch;
+                next();
+            }
+            while (ch >= "0" && ch <= "9") {
+                string += ch;
+                next();
+            }
+        }
+        value = +string;
+        if (!isFinite(value)) {
+            error("Bad number");
+        } else {
+            return value;
+        }
+    };
+
+    var string = function () {
+
+// Parse a string value.
+
+        var hex;
+        var i;
+        var value = "";
+        var uffff;
+
+// When parsing for string values, we must look for " and \ characters.
+
+        if (ch === "\"") {
+            while (next()) {
+                if (ch === "\"") {
+                    next();
+                    return value;
+                }
+                if (ch === "\\") {
+                    next();
+                    if (ch === "u") {
+                        uffff = 0;
+                        for (i = 0; i < 4; i += 1) {
+                            hex = parseInt(next(), 16);
+                            if (!isFinite(hex)) {
+                                break;
+                            }
+                            uffff = uffff * 16 + hex;
+                        }
+                        value += String.fromCharCode(uffff);
+                    } else if (typeof escapee[ch] === "string") {
+                        value += escapee[ch];
+                    } else {
+                        break;
+                    }
+                } else {
+                    value += ch;
+                }
+            }
+        }
+        error("Bad string");
+    };
+
+    var white = function () {
+
+// Skip whitespace.
+
+        while (ch && ch <= " ") {
+            next();
+        }
+    };
+
+    var word = function () {
+
+// true, false, or null.
+
+        switch (ch) {
+        case "t":
+            next("t");
+            next("r");
+            next("u");
+            next("e");
+            return true;
+        case "f":
+            next("f");
+            next("a");
+            next("l");
+            next("s");
+            next("e");
+            return false;
+        case "n":
+            next("n");
+            next("u");
+            next("l");
+            next("l");
+            return null;
+        }
+        error("Unexpected '" + ch + "'");
+    };
+
+    var value;  // Place holder for the value function.
+
+    var array = function () {
+
+// Parse an array value.
+
+        var arr = [];
+
+        if (ch === "[") {
+            next("[");
+            white();
+            if (ch === "]") {
+                next("]");
+                return arr;   // empty array
+            }
+            while (ch) {
+                arr.push(value());
+                white();
+                if (ch === "]") {
+                    next("]");
+                    return arr;
+                }
+                next(",");
+                white();
+            }
+        }
+        error("Bad array");
+    };
+
+    var object = function () {
+
+// Parse an object value.
+
+        var key;
+        var obj = {};
+
+        if (ch === "{") {
+            next("{");
+            white();
+            if (ch === "}") {
+                next("}");
+                return obj;   // empty object
+            }
+            while (ch) {
+                key = string();
+                white();
+                next(":");
+                if (Object.hasOwnProperty.call(obj, key)) {
+                    error("Duplicate key '" + key + "'");
+                }
+                obj[key] = value();
+                white();
+                if (ch === "}") {
+                    next("}");
+                    return obj;
+                }
+                next(",");
+                white();
+            }
+        }
+        error("Bad object");
+    };
+
+    value = function () {
+
+// Parse a JSON value. It could be an object, an array, a string, a number,
+// or a word.
+
+        white();
+        switch (ch) {
+        case "{":
+            return object();
+        case "[":
+            return array();
+        case "\"":
+            return string();
+        case "-":
+            return number();
+        default:
+            return (ch >= "0" && ch <= "9")
+                ? number()
+                : word();
+        }
+    };
+
+// Return the json_parse function. It will have access to all of the above
+// functions and variables.
+
+    return function (source, reviver) {
+        var result;
+
+        text = source;
+        at = 0;
+        ch = " ";
+        result = value();
+        white();
+        if (ch) {
+            error("Syntax error");
+        }
+
+// If there is a reviver function, we recursively walk the new structure,
+// passing each name/value pair to the reviver function for possible
+// transformation, starting with a temporary root object that holds the result
+// in an empty key. If there is not a reviver function, we simply return the
+// result.
+
+        return (typeof reviver === "function")
+            ? (function walk(holder, key) {
+                var k;
+                var v;
+                var val = holder[key];
+                if (val && typeof val === "object") {
+                    for (k in val) {
+                        if (Object.prototype.hasOwnProperty.call(val, k)) {
+                            v = walk(val, k);
+                            if (v !== undefined) {
+                                val[k] = v;
+                            } else {
+                                delete val[k];
+                            }
+                        }
+                    }
+                }
+                return reviver.call(holder, key, val);
+            }({"": result}, ""))
+            : result;
+    };
+}());

--- a/ide/tasks/archive.py
+++ b/ide/tasks/archive.py
@@ -267,7 +267,7 @@ def do_import_archive(project_id, archive, delete_project=False):
                                 file_exists_for_root[root_file_name] = True
 
                         elif filename.startswith(SRC_DIR):
-                            if (not filename.startswith('.')) and (filename.endswith('.c') or filename.endswith('.h') or filename.endswith('.js')):
+                            if not filename.startswith('.') and filename.endswith(('.c', '.h', '.js', '.json')):
                                 base_filename = filename[len(SRC_DIR):]
                                 if project.app_modern_multi_js and base_filename.endswith('.js') and base_filename.startswith('js/'):
                                     base_filename = base_filename[len('js/'):]
@@ -275,7 +275,7 @@ def do_import_archive(project_id, archive, delete_project=False):
                                 with z.open(entry.filename) as f:
                                     source.save_text(f.read().decode('utf-8'))
                         elif filename.startswith(WORKER_SRC_DIR):
-                            if (not filename.startswith('.')) and (filename.endswith('.c') or filename.endswith('.h') or filename.endswith('.js')):
+                            if not filename.startswith('.') and filename.endswith(('.c', '.h', '.js')):
                                 base_filename = filename[len(WORKER_SRC_DIR):]
                                 source = SourceFile.objects.create(project=project, file_name=base_filename, target='worker')
                                 with z.open(entry.filename) as f:

--- a/ide/tasks/gist.py
+++ b/ide/tasks/gist.py
@@ -91,7 +91,7 @@ def import_gist(user_id, gist_id):
 
         if project_type != 'simplyjs':
             for filename in gist.files:
-                if (project_type == 'native' and filename.endswith('.c') or filename.endswith('.h')) or filename.endswith('.js'):
+                if project_type == 'native' and filename.endswith(('.c', '.h', '.js', '.json')):
                     # Because gists can't have subdirectories.
                     if filename == 'pebble-js-app.js':
                         cp_filename = 'js/pebble-js-app.js'

--- a/ide/templates/ide/project.html
+++ b/ide/templates/ide/project.html
@@ -149,6 +149,7 @@
                     <select id="new-file-type">
                         <option value="c" selected>{% trans 'C file' %}</option>
                         <option value="js">{% trans 'JavaScript file' %}</option>
+                        <option value="json">{% trans 'JSON file' %}</option>
                         <option value="layout">{% trans 'Window Layout' %}</option>
                     </select>
                 </div>
@@ -174,6 +175,14 @@
                     <label class="control-label" for="new-c-generate-h">{% trans 'Create header' %}</label>
                     <div class="controls">
                         <input type="checkbox" id="new-c-generate-h">
+                    </div>
+                </div>
+            </div>
+            <div class="json-file-options file-group hide">
+                <div class="control-group">
+                    <label class="control-label" for="new-json-file-name">{% trans 'Filename' %}</label>
+                    <div class="controls">
+                        <input type="text" id="new-json-file-name" pattern="[a-zA-Z0-9_-]+\.json$">
                     </div>
                 </div>
             </div>
@@ -502,6 +511,7 @@ var REGEXES = _.mapObject(JSON.parse('{{regexes_json|escapejs}}'), function(v) {
 <script src="{% static 'CodeMirror/keymap/vim.js' %}"></script>
 <script src="{% static 'ide/external/uuid.js' %}"></script>
 <script src="/ide/jsi18n/"></script>
+<script src="{% static 'ide/js/json_parse.js' %}" type="text/javascript"></script>
 <script src="{% static 'ide/js/csrf.js' %}" type="text/javascript"></script>
 <script src="{% static 'ide/js/cloudpebble.js' %}" type="text/javascript"></script>
 <script src="{% static 'ide/js/sidebar.js' %}" type="text/javascript"></script>

--- a/ide/tests/test_create_archive.py
+++ b/ide/tests/test_create_archive.py
@@ -10,17 +10,18 @@ fake_s3 = FakeS3()
 
 
 class ExportTester(CloudpebbleTestCase):
-    def createProject(self, options=None):
+    def create_project(self, options=None, files=None):
         fake_s3.reset()
         self.login(options)
         self.project = Project.objects.get(pk=self.project_id)
-        SourceFile.objects.create(project=self.project, file_name="main.c", target="app").save_text('file_contents')
+        for name in (files if files else {'main.c'}):
+            SourceFile.objects.create(project=self.project, file_name=name, target="app").save_text('file_contents')
 
-    def run_test(self, expected_filenames, options=None):
-        self.createProject(options)
+    def run_test(self, expected_filenames):
         create_archive(self.project_id)
         data = read_bundle(fake_s3.read_last_file())
         filenames = set(data.keys())
+        expected_filenames = expected_filenames | {'test/src/main.c', 'test/wscript', 'test/jshintrc'}
         self.assertSetEqual(filenames, expected_filenames)
 
 
@@ -30,11 +31,13 @@ class ExportTester(CloudpebbleTestCase):
 class TestExportWithoutNPMSupport(ExportTester):
     def test_export_sdk_3_project(self):
         """ With package.json support off, check that SDK3 projects are exported with appinfo.json files """
-        self.run_test({'test/src/main.c', 'test/appinfo.json', 'test/wscript', 'test/jshintrc'})
+        self.create_project()
+        self.run_test({'test/appinfo.json'})
 
     def test_export_sdk_2_project(self):
         """ Check that SDK2 projects are exported with appinfo.json files """
-        self.run_test({'test/src/main.c', 'test/appinfo.json', 'test/wscript', 'test/jshintrc'}, {'sdk': '2'})
+        self.create_project({'sdk': '2'})
+        self.run_test({'test/appinfo.json'})
 
 
 @override_settings(NPM_MANIFEST_SUPPORT='yes')
@@ -43,8 +46,15 @@ class TestExportWithoutNPMSupport(ExportTester):
 class TestExportWithNPMSupport(ExportTester):
     def test_export_sdk_3_project(self):
         """ With package.json support off, check that SDK3 projects are exported with package.json files """
-        self.run_test({'test/src/main.c', 'test/package.json', 'test/wscript', 'test/jshintrc'})
+        self.create_project()
+        self.run_test({'test/package.json'})
 
     def test_export_sdk_2_project(self):
         """ Check that SDK2 projects are exported with appinfo.json files even with package.json support on """
-        self.run_test({'test/src/main.c', 'test/appinfo.json', 'test/wscript', 'test/jshintrc'}, {'sdk': '2'})
+        self.create_project({'sdk': '2'})
+        self.run_test({'test/appinfo.json'})
+
+    def test_export_json(self):
+        """ Check that json files are correctly exported """
+        self.create_project(files={'main.c', 'test.json'})
+        self.run_test({'test/package.json', 'test/src/test.json'})

--- a/ide/utils/regexes.py
+++ b/ide/utils/regexes.py
@@ -22,7 +22,7 @@ class RegexHolder(object):
         'resource_file_name': r'^[/a-zA-Z0-9_(). -]+$',
 
         # Match a valid c/h/js file name
-        'source_file_name': r'^[/a-zA-Z0-9_.-]+\.(c|h|js)$'
+        'source_file_name': r'^[/a-zA-Z0-9_.-]+\.(c|h|js|json)$'
     }
 
     def validator(self, key, message):

--- a/ide/utils/sdk.py
+++ b/ide/utils/sdk.py
@@ -171,12 +171,12 @@ def build(ctx):
         if build_worker:
             worker_elf = '{}/pebble-worker.elf'.format(ctx.env.BUILD_DIR)
             binaries.append({'platform': p, 'app_elf': app_elf, 'worker_elf': worker_elf})
-            ctx.pbl_worker(source=ctx.path.ant_glob('worker_src/**/*.c'), target=worker_elf)
+            ctx.pbl_worker(source=ctx.path.ant_glob(['worker_src/**/*.c', 'src/js/**/*.json']), target=worker_elf)
         else:
             binaries.append({'platform': p, 'app_elf': app_elf})
 
     ctx.set_group('bundle')
-    ctx.pbl_bundle(binaries=binaries, js=ctx.path.ant_glob('src/js/**/*.js'), js_entry_file='src/js/app.js')
+    ctx.pbl_bundle(binaries=binaries, js=ctx.path.ant_glob(['src/js/**/*.js', 'src/js/**/*.json']), js_entry_file='src/js/app.js')
 """
 
     return wscript.replace('{{jshint}}', 'True' if jshint and not for_export else 'False')


### PR DESCRIPTION
This enables creating and editing `.json` files on CloudPebble, and also includes some related changed/refactoring. A detailed list of changes:

- `.json` added to the database validation regex for valid source file names
- `.json` included in places which check `filename.endswith()` (i.e. import/export code)
- Updated wscript as described by [Clay's readme](https://github.com/pebble/clay)
- JSON option added to the new file dialog, which is also be available in pebblejs projects.
- Some refactoring in `editor.js`...
  - ... to use `file_kind` instead of the `is_js` flag. This is the same change made to support `.monkey` files in the test-bench branch.
  - ... in `init_create_prompt()` to factor out the repeated `.then(...).catch(...)` for each kind of file. 
- Added [json_parse.js](https://github.com/douglascrockford/JSON-js/blob/master/json_parse.js) which is used in place of JSHINT for `.json` files to get accurate real time json linting.
- Added two tests, for importing and exporting projects containing json files.

(Branched from #321)