### PR TITLE
PBL-39514: project import should pick most shallow possible project

### DIFF
--- a/ide/tests/test_find_project_root.py
+++ b/ide/tests/test_find_project_root.py
@@ -112,3 +112,12 @@ class TestFindProjectRoot(TestCase):
             "src/"
             "src/main.c",
         ], "", "package.json")
+
+    def test_find_most_shallow_project(self):
+        """ Check that the most shallow possible valid-looking project is chosen. """
+        self.run_test([
+            "build/appinfo.json",
+            "build/src/main.c",
+            "package.json",
+            "src/main.c",
+        ], "", "package.json")

--- a/ide/utils/project.py
+++ b/ide/utils/project.py
@@ -1,6 +1,6 @@
-import logging
 import abc
 import json
+import os.path
 
 from django.utils.translation import ugettext as _
 
@@ -50,7 +50,9 @@ def find_project_root_and_manifest(project_items):
     """
     SRC_DIR = 'src/'
 
-    for item in project_items:
+    # Sort the paths by the number of path separators they have,
+    sorted_items = sorted(project_items, key=lambda x: os.path.normpath(x.path).count('/'))
+    for i, item in enumerate(sorted_items):
         base_dir = item.path
 
         # Check if the file is one of the kinds of manifest file
@@ -70,8 +72,8 @@ def find_project_root_and_manifest(project_items):
         # The base dir is the location of the manifest file without the manifest filename.
         base_dir = base_dir[:dir_end]
 
-        # Now check that there is a a source directory containing at least one source file.
-        for source_item in project_items:
+        # Now check the rest of the items for a source directory containing at least one source file.
+        for source_item in sorted_items[i+1:]:
             source_dir = source_item.path
             if source_dir[:dir_end] != base_dir:
                 continue


### PR DESCRIPTION
If a user zips builds a project, then zips their project directory and attempts to upload it to CloudPebble, CloudPebble may think that the build directory is the project directory, because the search order is just the order of the files in the archive.

Instead, the import process should do a breadth-first search, which I have implemented here by just sorting the paths by the number of path separators before looking through them.

Additionally, the part of the algorithm which checks for "a source directory containing at least one source file" can just search the remainder of the list of paths since all deeper paths are guaranteed to be further in the list than the manifest.
