### PR TITLE
Preselect filename when renaming.

### DIFF
--- a/ide/static/ide/js/editor.js
+++ b/ide/static/ide/js/editor.js
@@ -550,7 +550,9 @@ CloudPebble.Editor = (function() {
                             prompt.error(gettext(interpolate("Failed to rename file. %s", [error.message])));
                         });
                     },
-                    pattern)
+                    pattern);
+                // Pre-select the filename without the extension.
+                $('#modal-text-input-value')[0].setSelectionRange(0, file.name.lastIndexOf('.'));
             };
 
             var ib_pane = $('#ui-editor-pane-template').clone().removeClass('hide').appendTo(pane).hide();


### PR DESCRIPTION
This adds a line of code which selects the file name in the rename textbox (without the extension) when renaming a file.