### PR TITLE
Add support for publishedMedia

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ RUN mkdir /sdk2 && \
   tar --strip-components=1 -xj -C /sdk2
 
 ENV SDK_THREE_CHANNEL=beta
-ENV SDK_THREE_VERSION=4.0-beta16
+ENV SDK_THREE_VERSION=4.0-beta17
 
 # Install SDK 3
 RUN mkdir /sdk3 && \

--- a/ide/api/project.py
+++ b/ide/api/project.py
@@ -50,6 +50,7 @@ def project_info(request, project_id):
         'app_platforms': project.app_platforms,
         'app_modern_multi_js': project.app_modern_multi_js,
         'menu_icon': project.menu_icon.id if project.menu_icon else None,
+        'published_media': project.get_published_media(),
         'source_files': [{
                              'name': f.file_name,
                              'id': f.id,
@@ -257,11 +258,26 @@ def save_project_dependencies(request, project_id):
     try:
         project.set_dependencies(json.loads(request.POST['dependencies']))
         project.set_interdependencies([int(x) for x in json.loads(request.POST['interdependencies'])])
-        return {'dependencies': project.get_dependencies()}
     except (IntegrityError, ValueError) as e:
         raise BadRequest(str(e))
     else:
-        send_td_event('cloudpebble_save_project_settings', request=request, project=project)
+        send_td_event('cloudpebble_save_dependencies', request=request, project=project)
+        return {'dependencies': project.get_dependencies()}
+
+
+@require_POST
+@login_required
+@json_view
+def save_published_media(request, project_id):
+    project = get_object_or_404(Project, pk=project_id, owner=request.user)
+    try:
+        project.set_published_media(json.loads(request.POST['published_media']))
+    except (IntegrityError, ValueError) as e:
+        raise BadRequest(str(e))
+    else:
+        send_td_event('cloudpebble_save_published_media', request=request, project=project)
+        return {'published_media': project.get_published_media()}
+
 
 @require_POST
 @login_required

--- a/ide/api/ycm.py
+++ b/ide/api/ycm.py
@@ -7,7 +7,9 @@ from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import get_object_or_404
 from django.views.decorators.http import require_POST
+from django.utils.translation import ugettext as _
 from urlparse import urlparse
+
 
 from ide.models.project import Project
 from utils.jsonview import json_view
@@ -38,7 +40,8 @@ def init_autocomplete(request, project_id):
         'sdk': request.POST.get('sdk', '2'),
         'messagekeys': appkey_names,
         'resources': identifiers,
-        'dependencies': project.get_dependencies()
+        'dependencies': project.get_dependencies(),
+        'published_media': [x.name for x in project.published_media.all()]
     }
     # Let's go!
     return _spin_up_server(request)

--- a/ide/api/ycm.py
+++ b/ide/api/ycm.py
@@ -69,6 +69,7 @@ def _spin_up_server(request):
                         'server': ws_server,
                         'secure': secure,
                         'libraries': response.get('libraries', {}),
+                        'resources': response.get('resources', []),
                         'npm_error': response.get('npm_error', None)
                     }
 

--- a/ide/migrations/0051_auto__add_publishedmedia__add_unique_publishedmedia_project_name.py
+++ b/ide/migrations/0051_auto__add_publishedmedia__add_unique_publishedmedia_project_name.py
@@ -1,0 +1,206 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'PublishedMedia'
+        db.create_table(u'ide_publishedmedia', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('project', self.gf('django.db.models.fields.related.ForeignKey')(related_name='published_media', to=orm['ide.Project'])),
+            ('name', self.gf('django.db.models.fields.CharField')(max_length=100)),
+            ('media_id', self.gf('django.db.models.fields.IntegerField')()),
+            ('glance', self.gf('django.db.models.fields.CharField')(max_length=100, blank=True)),
+            ('has_timeline', self.gf('django.db.models.fields.BooleanField')(default=False)),
+            ('timeline_tiny', self.gf('django.db.models.fields.CharField')(max_length=100, blank=True)),
+            ('timeline_small', self.gf('django.db.models.fields.CharField')(max_length=100, blank=True)),
+            ('timeline_large', self.gf('django.db.models.fields.CharField')(max_length=100, blank=True)),
+        ))
+        db.send_create_signal('ide', ['PublishedMedia'])
+
+        # Adding unique constraint on 'PublishedMedia', fields ['project', 'name']
+        db.create_unique(u'ide_publishedmedia', ['project_id', 'name'])
+
+
+    def backwards(self, orm):
+        # Removing unique constraint on 'PublishedMedia', fields ['project', 'name']
+        db.delete_unique(u'ide_publishedmedia', ['project_id', 'name'])
+
+        # Deleting model 'PublishedMedia'
+        db.delete_table(u'ide_publishedmedia')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'ide.buildresult': {
+            'Meta': {'object_name': 'BuildResult'},
+            'finished': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'builds'", 'to': "orm['ide.Project']"}),
+            'started': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'state': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'uuid': ('django.db.models.fields.CharField', [], {'default': "'8b836ddd-8bc8-4884-bdda-824481f7f05c'", 'max_length': '36'})
+        },
+        'ide.buildsize': {
+            'Meta': {'object_name': 'BuildSize'},
+            'binary_size': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'build': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'sizes'", 'to': "orm['ide.BuildResult']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'platform': ('django.db.models.fields.CharField', [], {'max_length': '20'}),
+            'resource_size': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'total_size': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'worker_size': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'})
+        },
+        'ide.dependency': {
+            'Meta': {'unique_together': "(('project', 'name'),)", 'object_name': 'Dependency'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'dependencies'", 'to': "orm['ide.Project']"}),
+            'version': ('django.db.models.fields.CharField', [], {'max_length': '2000'})
+        },
+        'ide.project': {
+            'Meta': {'object_name': 'Project'},
+            'app_capabilities': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'app_company_name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'app_is_hidden': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'app_is_shown_on_communication': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'app_is_watchface': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'app_jshint': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'app_keys': ('django.db.models.fields.TextField', [], {'default': "'{}'"}),
+            'app_keywords': ('django.db.models.fields.TextField', [], {'default': "'[]'"}),
+            'app_long_name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'app_modern_multi_js': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'app_platforms': ('django.db.models.fields.TextField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'app_short_name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'app_uuid': ('django.db.models.fields.CharField', [], {'default': "'488507d8-f7d8-449e-b2d9-36c05ba88d4c'", 'max_length': '36', 'null': 'True', 'blank': 'True'}),
+            'app_version_label': ('django.db.models.fields.CharField', [], {'default': "'1.0'", 'max_length': '40', 'null': 'True', 'blank': 'True'}),
+            'github_branch': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'github_hook_build': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'github_hook_uuid': ('django.db.models.fields.CharField', [], {'max_length': '36', 'null': 'True', 'blank': 'True'}),
+            'github_last_commit': ('django.db.models.fields.CharField', [], {'max_length': '40', 'null': 'True', 'blank': 'True'}),
+            'github_last_sync': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'github_repo': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_modified': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'optimisation': ('django.db.models.fields.CharField', [], {'default': "'s'", 'max_length': '1'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']"}),
+            'project_dependencies': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['ide.Project']", 'symmetrical': 'False'}),
+            'project_type': ('django.db.models.fields.CharField', [], {'default': "'native'", 'max_length': '10'}),
+            'sdk_version': ('django.db.models.fields.CharField', [], {'default': "'2'", 'max_length': '6'})
+        },
+        'ide.publishedmedia': {
+            'Meta': {'unique_together': "(('project', 'name'),)", 'object_name': 'PublishedMedia'},
+            'glance': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'}),
+            'has_timeline': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'media_id': ('django.db.models.fields.IntegerField', [], {}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'published_media'", 'to': "orm['ide.Project']"}),
+            'timeline_large': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'}),
+            'timeline_small': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'}),
+            'timeline_tiny': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'})
+        },
+        'ide.resourcefile': {
+            'Meta': {'unique_together': "(('project', 'file_name'),)", 'object_name': 'ResourceFile'},
+            'file_name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_menu_icon': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'kind': ('django.db.models.fields.CharField', [], {'max_length': '9'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'resources'", 'to': "orm['ide.Project']"})
+        },
+        'ide.resourceidentifier': {
+            'Meta': {'object_name': 'ResourceIdentifier'},
+            'character_regex': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'compatibility': ('django.db.models.fields.CharField', [], {'max_length': '10', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'memory_format': ('django.db.models.fields.CharField', [], {'max_length': '15', 'null': 'True', 'blank': 'True'}),
+            'resource_file': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'identifiers'", 'to': "orm['ide.ResourceFile']"}),
+            'resource_id': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'space_optimisation': ('django.db.models.fields.CharField', [], {'max_length': '7', 'null': 'True', 'blank': 'True'}),
+            'storage_format': ('django.db.models.fields.CharField', [], {'max_length': '3', 'null': 'True', 'blank': 'True'}),
+            'target_platforms': ('django.db.models.fields.CharField', [], {'default': 'None', 'max_length': '30', 'null': 'True', 'blank': 'True'}),
+            'tracking': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'})
+        },
+        'ide.resourcevariant': {
+            'Meta': {'unique_together': "(('resource_file', 'tags'),)", 'object_name': 'ResourceVariant'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_legacy': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'resource_file': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'variants'", 'to': "orm['ide.ResourceFile']"}),
+            'tags': ('django.db.models.fields.CommaSeparatedIntegerField', [], {'max_length': '50', 'blank': 'True'})
+        },
+        'ide.sourcefile': {
+            'Meta': {'unique_together': "(('project', 'file_name', 'target'),)", 'object_name': 'SourceFile'},
+            'file_name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'folded_lines': ('django.db.models.fields.TextField', [], {'default': "'[]'"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'null': 'True', 'blank': 'True'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'source_files'", 'to': "orm['ide.Project']"}),
+            'target': ('django.db.models.fields.CharField', [], {'default': "'app'", 'max_length': '10'})
+        },
+        'ide.templateproject': {
+            'Meta': {'object_name': 'TemplateProject', '_ormbases': ['ide.Project']},
+            u'project_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['ide.Project']", 'unique': 'True', 'primary_key': 'True'}),
+            'template_kind': ('django.db.models.fields.IntegerField', [], {'db_index': 'True'})
+        },
+        'ide.usergithub': {
+            'Meta': {'object_name': 'UserGithub'},
+            'avatar': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'nonce': ('django.db.models.fields.CharField', [], {'max_length': '36', 'null': 'True', 'blank': 'True'}),
+            'token': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'github'", 'unique': 'True', 'primary_key': 'True', 'to': u"orm['auth.User']"}),
+            'username': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'})
+        },
+        'ide.usersettings': {
+            'Meta': {'object_name': 'UserSettings'},
+            'accepted_terms': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'autocomplete': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'keybinds': ('django.db.models.fields.CharField', [], {'default': "'default'", 'max_length': '20'}),
+            'tab_width': ('django.db.models.fields.PositiveSmallIntegerField', [], {'default': '2'}),
+            'theme': ('django.db.models.fields.CharField', [], {'default': "'cloudpebble'", 'max_length': '50'}),
+            'use_spaces': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'user': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['auth.User']", 'unique': 'True', 'primary_key': 'True'}),
+            'whats_new': ('django.db.models.fields.PositiveIntegerField', [], {'default': '23'})
+        }
+    }
+
+    complete_apps = ['ide']

--- a/ide/migrations/0051_auto__add_publishedmedia__add_unique_publishedmedia_project_name.py
+++ b/ide/migrations/0051_auto__add_publishedmedia__add_unique_publishedmedia_project_name.py
@@ -25,8 +25,14 @@ class Migration(SchemaMigration):
         # Adding unique constraint on 'PublishedMedia', fields ['project', 'name']
         db.create_unique(u'ide_publishedmedia', ['project_id', 'name'])
 
+        # Adding unique constraint on 'PublishedMedia', fields ['project', 'media_id']
+        db.create_unique(u'ide_publishedmedia', ['project_id', 'media_id'])
+
 
     def backwards(self, orm):
+        # Removing unique constraint on 'PublishedMedia', fields ['project', 'media_id']
+        db.delete_unique(u'ide_publishedmedia', ['project_id', 'media_id'])
+
         # Removing unique constraint on 'PublishedMedia', fields ['project', 'name']
         db.delete_unique(u'ide_publishedmedia', ['project_id', 'name'])
 
@@ -78,7 +84,7 @@ class Migration(SchemaMigration):
             'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'builds'", 'to': "orm['ide.Project']"}),
             'started': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'db_index': 'True', 'blank': 'True'}),
             'state': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
-            'uuid': ('django.db.models.fields.CharField', [], {'default': "'8b836ddd-8bc8-4884-bdda-824481f7f05c'", 'max_length': '36'})
+            'uuid': ('django.db.models.fields.CharField', [], {'default': "'f59cc0ab-c224-4308-9401-e2c34ae88798'", 'max_length': '36'})
         },
         'ide.buildsize': {
             'Meta': {'object_name': 'BuildSize'},
@@ -111,7 +117,7 @@ class Migration(SchemaMigration):
             'app_modern_multi_js': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
             'app_platforms': ('django.db.models.fields.TextField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
             'app_short_name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
-            'app_uuid': ('django.db.models.fields.CharField', [], {'default': "'488507d8-f7d8-449e-b2d9-36c05ba88d4c'", 'max_length': '36', 'null': 'True', 'blank': 'True'}),
+            'app_uuid': ('django.db.models.fields.CharField', [], {'default': "'2a0eca7f-7b2b-49dd-a5f8-ae6a482b8c4a'", 'max_length': '36', 'null': 'True', 'blank': 'True'}),
             'app_version_label': ('django.db.models.fields.CharField', [], {'default': "'1.0'", 'max_length': '40', 'null': 'True', 'blank': 'True'}),
             'github_branch': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
             'github_hook_build': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
@@ -129,7 +135,7 @@ class Migration(SchemaMigration):
             'sdk_version': ('django.db.models.fields.CharField', [], {'default': "'2'", 'max_length': '6'})
         },
         'ide.publishedmedia': {
-            'Meta': {'unique_together': "(('project', 'name'),)", 'object_name': 'PublishedMedia'},
+            'Meta': {'unique_together': "(('project', 'name'), ('project', 'media_id'))", 'object_name': 'PublishedMedia'},
             'glance': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'}),
             'has_timeline': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
@@ -199,7 +205,7 @@ class Migration(SchemaMigration):
             'theme': ('django.db.models.fields.CharField', [], {'default': "'cloudpebble'", 'max_length': '50'}),
             'use_spaces': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
             'user': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['auth.User']", 'unique': 'True', 'primary_key': 'True'}),
-            'whats_new': ('django.db.models.fields.PositiveIntegerField', [], {'default': '23'})
+            'whats_new': ('django.db.models.fields.PositiveIntegerField', [], {'default': '24'})
         }
     }
 

--- a/ide/models/__init__.py
+++ b/ide/models/__init__.py
@@ -5,3 +5,4 @@ from ide.models.files import *
 from ide.models.project import *
 from ide.models.user import *
 from ide.models.dependency import *
+from ide.models.published_media import *

--- a/ide/models/published_media.py
+++ b/ide/models/published_media.py
@@ -50,8 +50,10 @@ class PublishedMedia(IdeModel):
             raise ValidationError(_("If glance and timeline.tiny are both used, they must be identical."))
         if self.has_timeline and not (self.timeline_tiny and self.timeline_small and self.timeline_large):
             raise ValidationError(_("If timeline icons are enabled, they must all be set."))
+        if not self.glance and not self.has_timeline:
+            raise ValidationError(_("Glance and Timeline cannot both be unset."))
         if self.media_id < 0:
             raise ValidationError(_("Published Media IDs cannot be negative."))
 
     class Meta(IdeModel.Meta):
-        unique_together = (('project', 'name'),)
+        unique_together = (('project', 'name'), ('project', 'media_id'))

--- a/ide/models/published_media.py
+++ b/ide/models/published_media.py
@@ -18,14 +18,17 @@ class PublishedMedia(IdeModel):
 
     @classmethod
     def from_dict(cls, project, data):
-        obj = cls.objects.create(project=project, name=data['name'], media_id=data['id'])
-        if 'glance' in data:
-            obj.glance = data['glance']
-        if 'timeline' in data:
-            obj.timeline_tiny = data['timeline']['tiny']
-            obj.timeline_small = data['timeline']['small']
-            obj.timeline_large = data['timeline']['large']
-        return obj
+        return cls.objects.create(
+            project=project,
+            name=data['name'],
+            media_id=data.get('id', None),
+            glance=data.get('glance', ''),
+            has_timeline=('timeline' in data),
+            timeline_tiny=data.get('timeline', {}).get('tiny', ''),
+            timeline_small=data.get('timeline', {}).get('small', ''),
+            timeline_large=data.get('timeline', {}).get('large', '')
+        )
+
 
     def to_dict(self):
         obj = {

--- a/ide/models/published_media.py
+++ b/ide/models/published_media.py
@@ -1,0 +1,54 @@
+from django.db import models
+from django.core.exceptions import ValidationError
+from django.utils.translation import ugettext_lazy as _
+
+from ide.utils.regexes import regexes
+from ide.models.meta import IdeModel
+
+
+class PublishedMedia(IdeModel):
+    project = models.ForeignKey('Project', related_name='published_media')
+    name = models.CharField(max_length=100, validators=regexes.validator('c_identifier', _('Invalid identifier')))
+    media_id = models.IntegerField()
+    glance = models.CharField(max_length=100, blank=True,  validators=regexes.validator('c_identifier', _('Invalid identifier')))
+    has_timeline = models.BooleanField(default=False)
+    timeline_tiny = models.CharField(max_length=100, blank=True, validators=regexes.validator('c_identifier', _('Invalid identifier')))
+    timeline_small = models.CharField(max_length=100, blank=True, validators=regexes.validator('c_identifier', _('Invalid identifier')))
+    timeline_large = models.CharField(max_length=100, blank=True, validators=regexes.validator('c_identifier', _('Invalid identifier')))
+
+    @classmethod
+    def from_dict(cls, project, data):
+        obj = cls.objects.create(project=project, name=data['name'], media_id=data['id'])
+        if 'glance' in data:
+            obj.glance = data['glance']
+        if 'timeline' in data:
+            obj.timeline_tiny = data['timeline']['tiny']
+            obj.timeline_small = data['timeline']['small']
+            obj.timeline_large = data['timeline']['large']
+        return obj
+
+    def to_dict(self):
+        obj = {
+            'name': self.name,
+            'id': self.media_id
+        }
+        if self.glance:
+            obj['glance'] = self.glance
+        if self.has_timeline:
+            obj['timeline'] = {
+                'tiny': self.timeline_tiny,
+                'small': self.timeline_small,
+                'large': self.timeline_large
+            }
+        return obj
+
+    def clean(self):
+        if self.has_timeline and self.glance and self.glance != self.timeline_tiny:
+            raise ValidationError(_("If glance and timeline.tiny are both used, they must be identical."))
+        if self.has_timeline and not (self.timeline_tiny and self.timeline_small and self.timeline_large):
+            raise ValidationError(_("If timeline icons are enabled, they must all be set."))
+        if self.media_id < 0:
+            raise ValidationError(_("Published Media IDs cannot be negative."))
+
+    class Meta(IdeModel.Meta):
+        unique_together = (('project', 'name'),)

--- a/ide/static/ide/css/ide.css
+++ b/ide/static/ide/css/ide.css
@@ -641,7 +641,7 @@ table.build-results tr.pending .build-state {
     clear: both;
 }
 
-.resource-pane input:not([type=checkbox]):not([type=submit]) {
+.resource-pane input:not([type=checkbox]):not([type=submit]):not([type=number]) {
     width: 435px;
 }
 
@@ -676,6 +676,14 @@ table.build-results tr.pending .build-state {
     width: 188px;
 }
 
+/* Published media pane */
+
+/*.media-pane .well {*/
+    /*margin: 30px;*/
+    /*padding-left: 60px;*/
+    /*padding-right: 60px;*/
+    /*width: 590px;*/
+/*}*/
 
 /* Dependancies pane */
 
@@ -1188,7 +1196,7 @@ button#add-filter {
     display: table;
 }
 
-.edit-resource-target-platforms-enabled:not(:checked) ~ .edit-resource-targets {
+.form-section-toggle:not(:checked) ~ .form-toggleable-section {
     display: none;
 }
 

--- a/ide/static/ide/css/ide.css
+++ b/ide/static/ide/css/ide.css
@@ -678,12 +678,9 @@ table.build-results tr.pending .build-state {
 
 /* Published media pane */
 
-/*.media-pane .well {*/
-    /*margin: 30px;*/
-    /*padding-left: 60px;*/
-    /*padding-right: 60px;*/
-    /*width: 590px;*/
-/*}*/
+.media-item:not(:first-child) .help-block {
+    display: none;
+}
 
 /* Dependancies pane */
 

--- a/ide/static/ide/css/ide.css
+++ b/ide/static/ide/css/ide.css
@@ -530,8 +530,9 @@ table.kv-table .kv-remove {
 .compilation-pane #run-on-phone .btn,
 .compilation-pane #run-on-qemu .btn,
 .compilation-pane .build-buttons .btn {
-    width: 137px;
+    min-width: 137px;
     margin: 0 4px;
+    wdith: initial;
 }
 
 .compilation-pane #run-on-phone .btn:last-of-type,
@@ -684,6 +685,7 @@ table.build-results tr.pending .build-state {
 
 .media-tool-buttons button {
     width: initial;
+    min-width: 130px;
     margin-right: 10px;
 }
 

--- a/ide/static/ide/css/ide.css
+++ b/ide/static/ide/css/ide.css
@@ -682,6 +682,30 @@ table.build-results tr.pending .build-state {
     display: none;
 }
 
+.media-tool-buttons button {
+    width: initial;
+    margin-right: 10px;
+}
+
+.sidebar-error::after {
+    content: "!";
+}
+
+.sidebar-error {
+    background: #e5171f;
+    display: inline-block;
+    color: white;
+    width: 22px;
+    text-align: center;
+    font-family: serif;
+    border-radius: 20px;
+    padding-right: 1px;
+    margin-top: -1px;
+}
+.sidebar-error.hide {
+    display: none;
+}
+
 /* Dependancies pane */
 
 .dependencies-pane .well {

--- a/ide/static/ide/js/cloudpebble.js
+++ b/ide/static/ide/js/cloudpebble.js
@@ -61,7 +61,6 @@ CloudPebble.Init = function() {
         CloudPebble.Compile.Init();
         CloudPebble.Editor.Init();
         CloudPebble.Resources.Init();
-        CloudPebble.PublishedMedia.Init();
         CloudPebble.Sidebar.Init();
         CloudPebble.Settings.Init();
         CloudPebble.GitHub.Init();
@@ -78,6 +77,7 @@ CloudPebble.Init = function() {
         $.each(data.resources, function(index, value) {
             CloudPebble.Resources.Add(value);
         });
+        CloudPebble.PublishedMedia.Init();
         CloudPebble.Emulator.init();
         CloudPebble.YCM.initialise();
         CloudPebble.Sidebar.SetProjectType(data.type);

--- a/ide/static/ide/js/cloudpebble.js
+++ b/ide/static/ide/js/cloudpebble.js
@@ -61,6 +61,7 @@ CloudPebble.Init = function() {
         CloudPebble.Compile.Init();
         CloudPebble.Editor.Init();
         CloudPebble.Resources.Init();
+        CloudPebble.PublishedMedia.Init();
         CloudPebble.Sidebar.Init();
         CloudPebble.Settings.Init();
         CloudPebble.GitHub.Init();

--- a/ide/static/ide/js/dependencies.js
+++ b/ide/static/ide/js/dependencies.js
@@ -384,6 +384,7 @@ CloudPebble.Dependencies = (function() {
             return CloudPebble.YCM.updateDependencies(result.dependencies);
         }).then(function(result) {
             if (result) {
+                CloudPebble.PublishedMedia.SetDependencyResources(result.data.resources);
                 update_header_list(result.data.libraries)
             }
         });

--- a/ide/static/ide/js/dependencies.js
+++ b/ide/static/ide/js/dependencies.js
@@ -551,7 +551,7 @@ CloudPebble.Dependencies = (function() {
     }
 
     /** This sets up the list of headers */
-    function setup_headers_pane(pane, alerts) {
+    function setup_headers_pane(pane) {
         // Select an entire header when it is clicked.
         pane.on('click', 'tbody a', function() {
             select_element(this);

--- a/ide/static/ide/js/live_settings_form.js
+++ b/ide/static/ide/js/live_settings_form.js
@@ -234,8 +234,8 @@ function make_live_settings_form(options) {
         init: function() {
             init();
         },
-        save: function(element) {
-            return save(element);
+        save: function(element, event) {
+            return save(element, event);
         }
     };
 }

--- a/ide/static/ide/js/live_settings_form.js
+++ b/ide/static/ide/js/live_settings_form.js
@@ -24,6 +24,7 @@ function make_live_settings_form(options) {
         on_save: null,
         on_change: null,
         on_progress_started: null,
+        auto_save: true,
         on_progress_complete: null,
         progress_timeout: 300,
         control_selector: 'input, select, textarea',
@@ -213,7 +214,9 @@ function make_live_settings_form(options) {
             if (_.isFunction(opts.on_change)) {
                 opts.on_change(this);
             }
-            save($(this), e);
+            if (opts.auto_save) {
+                save($(this), e);
+            }
         });
 
         // While typing in text forms, show the changed icon
@@ -225,9 +228,6 @@ function make_live_settings_form(options) {
     }
 
     return {
-        clearIcons: function() {
-            clear_changed_icons();
-        },
         addElement: function(elements, changed) {
             add_status_icons(elements, changed);
         },
@@ -235,7 +235,7 @@ function make_live_settings_form(options) {
             init();
         },
         save: function(element) {
-            save(element);
+            return save(element);
         }
     };
 }

--- a/ide/static/ide/js/published_media.js
+++ b/ide/static/ide/js/published_media.js
@@ -1,0 +1,152 @@
+CloudPebble.PublishedMedia = (function() {
+    var media_template = null;
+    var item_template = null;
+
+    function get_default_data() {
+            return {
+                name: '',
+                id: make_new_id()
+            }
+        }
+
+    function make_new_id() {
+        return _.max(media_template.find('.edit-media-id').map(function() {return parseInt(this.value, 10)})) + 1;
+    }
+
+    function get_form_data() {
+        return media_template.find('.media-item').map(function() {
+            var item = $(this);
+            var glance = item.find('.edit-media-glance').val();
+            var has_timeline = item.find('.edit-media-timeline').prop('checked');
+            var data = {
+                name: item.find('.edit-media-name').val(),
+                id: parseInt(item.find('.edit-media-id').val(), 10)
+            };
+            if (glance) data.glance = glance;
+            if (has_timeline) {
+                data.timeline = {
+                    tiny: item.find('.edit-media-timeline-tiny').val(),
+                    small: item.find('.edit-media-timeline-small').val(),
+                    large: item.find('.edit-media-timeline-large').val()
+                }
+            }
+            return data;
+        }).toArray();
+    }
+
+    /** This singleton manages the error box and loading indicator. */
+    var alerts = new (function Alerts() {
+        var pane;
+        this.show_error = function show_error(error) {
+            pane.find('.alert-error').removeClass('hide').text(error);
+        };
+        this.hide_error = function hide_error() {
+            pane.find('.alert-error').addClass('hide');
+        };
+        this.init = function(set_pane) {
+            pane = set_pane;
+        }
+    });
+
+    function get_eligable_identifiers() {
+        return _.chain(CloudPebble.Resources.GetResources()).filter(function(item) {
+            return /^(png|pbi|bitmap|raw)/.test(item.kind);
+        }).pluck('identifiers').flatten().uniq().value();
+    }
+
+    function make_new_media_item() {
+        var item_form = media_template.find('form');
+        var new_item = item_template.clone().appendTo(item_form);
+        set_form_options(new_item);
+        set_media_item_data(new_item, publishedMedia.get_default_data());
+        return new_item;
+    }
+
+    function set_media_item_data(element, data) {
+        element.find('.edit-media-name').val(data.name);
+        element.find('.edit-media-id').val(data.id);
+        element.find('.edit-media-glance').val(data.glance || '');
+        element.find('.edit-media-timeline').prop('checked', !!data.timeline);
+        if (data.timeline) {
+            element.find('.edit-media-timeline-tiny').val(data.timeline.tiny);
+            element.find('.edit-media-timeline-small').val(data.timeline.small);
+            element.find('.edit-media-timeline-large').val(data.timeline.large);
+        }
+        else {
+            // Default to the first option if the there is no specified timeline data.
+            element.find('.edit-media-timeline-options option').prop('selected', false);
+            element.find('.edit-media-timeline-options select').find('option:first').prop('selected', true);
+        }
+    }
+
+    function set_form_options(parent) {
+        var identifiers = get_eligable_identifiers();
+        parent.find(".media-resource-selector").each(function() {
+            var select = $(this).empty();
+            var value = select.val();
+            if (select.hasClass('media-optional-selector')) {
+                select.append($('<option>').val('').text('-- None --'));
+            }
+            select.append(_.map(identifiers, function(identifier) {
+                return $('<option>').val(identifier).text(identifier);
+            })).val(value);
+        })
+    }
+
+    function setup_media_pane() {
+        var initial_data = [{
+            name: 'BLAH',
+            id: 0,
+            glance: 'THING',
+            timeline: {
+                tiny: 'THING',
+                small: 'THING2',
+                large: 'THING2'
+            }
+        }];
+        _.each(initial_data, function(item) {
+            var entry = make_new_media_item();
+            set_media_item_data(entry, item);
+        });
+
+        media_template.find('#add-published-media').click(function() {
+            make_new_media_item();
+        });
+    }
+    function show_media_pane() {
+        CloudPebble.Sidebar.SuspendActive();
+        if (CloudPebble.Sidebar.Restore("published-media")) {
+            return;
+        }
+        ga('send', 'event', 'project', 'load published-media');
+        setup_media_pane();
+        CloudPebble.Sidebar.SetActivePane(media_template, {
+            id: 'published-media'
+        });
+    }
+
+    return {
+        Show: function() {
+            show_media_pane();
+        },
+        GetPublishedMedia: function() {
+            return publishedMedia.get_data();
+        },
+        Init: function() {
+            var commands = {};
+            commands[gettext("Published Media")] = CloudPebble.PublishedMedia.Show;
+            CloudPebble.FuzzyPrompt.AddCommands(commands);
+            media_template = $('#media-pane-template').remove().removeClass('hide');
+            item_template = $('#media-item-template').removeAttr('id').removeClass('hide').remove();
+            alerts.init(media_template);
+
+            // CloudPebble.YCM.initialise().then(function(data) {
+            //     if (data.libraries) {
+            //         update_header_file_list(data.libraries)
+            //     }
+            // }).finally(function() {
+            //     alerts.hide_progress();
+            // });
+        }
+    };
+})();

--- a/ide/static/ide/js/published_media.js
+++ b/ide/static/ide/js/published_media.js
@@ -24,6 +24,7 @@ CloudPebble.PublishedMedia = (function() {
         var pane;
         this.show_error = function show_error(error) {
             pane.find('.alert-error').removeClass('hide').text(error);
+            $('#main-pane').animate({scrollTop: 0})
         };
         this.hide_error = function hide_error() {
             pane.find('.alert-error').addClass('hide');
@@ -59,7 +60,7 @@ CloudPebble.PublishedMedia = (function() {
     function MediaItem() {
         var self = this;
         var deleting = false;
-        var item_form = media_template.find('form');
+        var item_form = media_template.find('#media-items');
         var item = item_template.clone().appendTo(item_form).data('item', this);
         var name_input = item.find('.edit-media-name');
         var id_input = item.find('.edit-media-id');
@@ -226,10 +227,6 @@ CloudPebble.PublishedMedia = (function() {
         if (!_.every(names)) {
             throw new Error(gettext('Identifiers cannot be blank'));
         }
-        // Check that all IDs are unique
-        if (_.max(_.countBy(data, 'id')) > 1) {
-            throw new Error(gettext('Numeric IDs must be unique'));
-        }
         // Check that all identifiers are valid
         _.each(names, function(name) {
             if (!REGEXES.c_identifier.test(name)) {
@@ -238,8 +235,7 @@ CloudPebble.PublishedMedia = (function() {
         });
         return Ajax.Post('/ide/project/' + PROJECT_ID + '/save_published_media', {
             'published_media': JSON.stringify(data)
-        }).then(function(result) {
-            // TODO: use 'result' or not?
+        }).then(function() {
             CloudPebble.ProjectInfo.published_media = data;
             sync_with_ycm();
             return null;
@@ -247,24 +243,42 @@ CloudPebble.PublishedMedia = (function() {
     }
 
     /** Save the whole form. If any names are incomplete or resources are invalid, it simply refuses to save without error. */
-    function save_forms() {
-        var items = get_media_items();
+    function save_forms(event) {
         var data = get_form_data();
+        var do_cancel = event.type != 'submit';
+        var items = get_media_items();
         var identifiers = get_eligible_identifiers();
+        function maybe_error(text) {
+            if (do_cancel) return {incomplete: true};
+            throw new Error(text);
+        }
         // If not all items have names, cancel saving without displaying an error
         if (!_.every(_.pluck(data, 'name'))) {
-            return {incomplete: true};
+            return maybe_error(gettext("Published Media must have non-empty identifiers."))
         }
-        // Raise an error if there are any invalid selections
+
+        // Cancel if there are any incomplete items
+        if (!_.every(_.map(data, function(item) {
+                return !!item.timeline || !!item.glance;
+        }))) {
+            return maybe_error(gettext("Published Media items must specify glance, timeline icons, or both."))
+        }
+
+        // Check that all IDs are unique
+        if (_.max(_.countBy(data, 'id')) > 1) {
+            return maybe_error(gettext("Published Media IDs must be unique."))
+        }
+
+        // Cancel (and show the 'invalid items' icon in the sidebar) if there are any invalid values
         var validity = _.map(items, function(item) {return item.is_valid(identifiers);});
         if (!_.every(validity)) {
             toggle_sidebar_error(true);
-            return {incomplete: true};
+            return maybe_error(gettext("You cannot save Published Media items with references to resuorces which do not exist."))
         }
 
-        // If we successfully saved, it implies that there were no invalid references
-        // so we can get rid of the sidebar error notification.
         return save_pubished_media(data).then(function() {
+            // If we successfully saved, it implies that there were no invalid references
+            // so we can get rid of the sidebar error notification.
             toggle_sidebar_error(false);
         });
     }
@@ -274,10 +288,15 @@ CloudPebble.PublishedMedia = (function() {
         if (media_pane_setup) return false;
         media_pane_setup = true;
 
-        var initial_data = CloudPebble.ProjectInfo.published_media;
-        _.each(initial_data, function(data) {
+        // Set up the data
+        _.each(CloudPebble.ProjectInfo.published_media, function(data) {
             var item = new MediaItem();
             item.setData(data);
+        });
+
+        media_template.find('form').submit(function(e) {
+            live_form.save(null, e);
+            return false;
         });
 
         media_template.find('#add-published-media').click(function() {
@@ -290,7 +309,7 @@ CloudPebble.PublishedMedia = (function() {
             error_function: alerts.show_error,
             on_progress_started: alerts.show_progress,
             on_progress_complete: alerts.hide_progress,
-            form: media_template.find('form')
+            form: media_template.find('#media-items')
         });
         media_template.find('.media-tool-buttons').removeClass('hide');
         media_template.find('.media-pane-loading').remove();

--- a/ide/static/ide/js/resources.js
+++ b/ide/static/ide/js/resources.js
@@ -478,7 +478,7 @@ CloudPebble.Resources = (function() {
 
             var save = function(e) {
                 if (e) e.preventDefault();
-                process_resource_form(form, false, resource.file_name, "/ide/project/" + PROJECT_ID + "/resource/" + resource.id + "/update").then(function(data) {
+                return process_resource_form(form, false, resource.file_name, "/ide/project/" + PROJECT_ID + "/resource/" + resource.id + "/update").then(function(data) {
                     delete project_resources[resource.file_name];
                     // Update our information about the resource.
                     update_resource(data);
@@ -495,6 +495,16 @@ CloudPebble.Resources = (function() {
                         });
                     }
 
+                    // Attempt to rename any PublishedMedia which referenced these resource IDs.
+                    CloudPebble.PublishedMedia.RenameIdentifiers(pane.find('.edit-resource-id').map(function() {
+                        var old_id = $(this).data('old-value');
+                        var new_id = $(this).val();
+                        $(this).data('old-value', new_id);
+                        return [{from: old_id, to: new_id}];
+                    }).filter(function() {
+                        return !!this.from && this.from != this.to;
+                    }).toArray());
+
                     // Clear and disable the upload-file form
                     pane.find('#edit-resource-new-file input').val('');
                     pane.find('#edit-resource-new-file textarea').textext()[0].tags().empty().core().enabled(false);
@@ -503,7 +513,8 @@ CloudPebble.Resources = (function() {
 
                     // Only show the delete-identifiers button if there is more than one ID.
                     pane.find('.btn-delidentifier').toggle(resource.resource_ids.length > 1);
-                }).catch(function() {/* ignore failure */});;
+                    return null;
+                }).catch(function() {/* ignore failure */});
             };
 
             // Generate a preview.
@@ -589,6 +600,7 @@ CloudPebble.Resources = (function() {
                 group.find('.font-preview').remove();
                 var regex_str = group.find('.edit-resource-regex').val();
                 var id_str = group.find('.edit-resource-id').val();
+
                 var preview_regex = new RegExp('');
                 try {
                     preview_regex = new RegExp(regex_str ? regex_str : '.', 'g');
@@ -652,7 +664,7 @@ CloudPebble.Resources = (function() {
                     CloudPebble.Prompts.Confirm(gettext("Do you want to delete this resource identifier?"), gettext("This cannot be undone."), function () {
                         group.remove();
                         CloudPebble.Sidebar.SetIcon('resource-'+resource.id, 'edit');
-                        save_form();
+                        live_form.save();
                     });
                 });
             };
@@ -662,7 +674,9 @@ CloudPebble.Resources = (function() {
             $.each(resource.resource_ids, function(index, value) {
                 var group = template.clone();
                 group.removeClass('hide').attr('id','');
-                group.find('.edit-resource-id').val(value.id);
+                group.find('.edit-resource-id').val(value.id).data('old-value', value.id);
+                console.log("Set resource ID's value", value.id);
+
                 if (resource.kind == 'font') {
                     group.find('.edit-resource-regex').val(value.regex);
                     group.find('.edit-resource-tracking').val(value.tracking || '0');
@@ -739,6 +753,7 @@ CloudPebble.Resources = (function() {
                         delete project_resources[resource.file_name];
                         list_entry.remove();
                         CloudPebble.Settings.RemoveResource(resource);
+                        CloudPebble.PublishedMedia.ValidateIdentifiers();
                     }).catch(function(error) {
                         alert(error);
                     }).finally(function() {
@@ -761,13 +776,17 @@ CloudPebble.Resources = (function() {
                 }
             });
             live_form.init();
-            var save_form = function() {
+            form.submit(function() {
                 live_form.save();
                 return false;
-            };
-            form.submit(save_form);
+            });
             CloudPebble.GlobalShortcuts.SetShortcutHandlers({
-                save: save_form
+                save: function() {
+                    // Blur the active element to keep the form submission behaviour consistent
+                    // with pressing "enter".
+                    form.find('*:focus').blur();
+                    form.submit();
+                }
             });
 
             restore_pane(pane);

--- a/ide/static/ide/js/resources.js
+++ b/ide/static/ide/js/resources.js
@@ -439,11 +439,9 @@ CloudPebble.Resources = (function() {
         remove_error();
         disable_controls();
         ga('send', 'event', 'resource', 'save');
-        // TODO: CHECK THIS IS CORRECT!!!!!
         return Promise.resolve().then(function() {
             return get_resource_form_data(form, is_new, current_filename);
         }).then(function(resource_data) {
-            console.log(resource_data);
             return save_resource(url, resource_data);
         }).then(function(data) {
             return data.file;
@@ -502,7 +500,6 @@ CloudPebble.Resources = (function() {
                     pane.find('#edit-resource-new-file textarea').textext()[0].tags().empty().core().enabled(false);
                     pane.find('#edit-resource-new-file').toggleClass('file-present', false);
                     CloudPebble.Sidebar.ClearIcon('resource-'+resource.id);
-                    live_form.clearIcons();
 
                     // Only show the delete-identifiers button if there is more than one ID.
                     pane.find('.btn-delidentifier').toggle(resource.resource_ids.length > 1);
@@ -652,10 +649,10 @@ CloudPebble.Resources = (function() {
 
             var initialise_resource_id_group = function(group, resource) {
                 group.find('.btn-delidentifier').click(function() {
-                    CloudPebble.Prompts.Confirm(gettext("Do you want to this resource identifier?"), gettext("This cannot be undone."), function () {
+                    CloudPebble.Prompts.Confirm(gettext("Do you want to delete this resource identifier?"), gettext("This cannot be undone."), function () {
                         group.remove();
                         CloudPebble.Sidebar.SetIcon('resource-'+resource.id, 'edit');
-                        save();
+                        save_form();
                     });
                 });
             };
@@ -756,16 +753,21 @@ CloudPebble.Resources = (function() {
             var live_form = make_live_settings_form({
                 form: form,
                 save_function: function() {
-                    return null;
+                    save();
                 },
+                auto_save: false,
                 on_change: function() {
                     CloudPebble.Sidebar.SetIcon('resource-'+resource.id, 'edit');
                 }
-            }).init();
-
-            form.submit(save);
+            });
+            live_form.init();
+            var save_form = function() {
+                live_form.save();
+                return false;
+            };
+            form.submit(save_form);
             CloudPebble.GlobalShortcuts.SetShortcutHandlers({
-                save: save
+                save: save_form
             });
 
             restore_pane(pane);

--- a/ide/static/ide/js/resources.js
+++ b/ide/static/ide/js/resources.js
@@ -54,7 +54,7 @@ CloudPebble.Resources = (function() {
     function get_target_platforms(pane) {
         pane = $(pane);
         // Return null any IDs in the pane have no targetPlatforms enabled
-        if (pane.find('.edit-resource-target-platforms-enabled').is(":not(:checked)")) {
+        if (pane.find('.form-section-toggle').is(":not(:checked)")) {
             return null;
         }
         // Otherwise, return the union of all targetPlatforms set in the pane.
@@ -690,7 +690,7 @@ CloudPebble.Resources = (function() {
 
                 var has_target_platforms = _.isArray(value["target_platforms"]);
                 if (has_target_platforms) {
-                    var target_platforms_checkbox = group.find(".edit-resource-target-platforms-enabled");
+                    var target_platforms_checkbox = group.find(".form-section-toggle");
                     target_platforms_checkbox.prop('checked', true);
                     _.each(_.keys(PLATFORMS), function(platform) {
                         group.find(".edit-resource-target-"+platform).prop('checked', _.contains(value["target_platforms"], platform));
@@ -963,6 +963,9 @@ CloudPebble.Resources = (function() {
         },
         GetFonts: function() {
             return _.where(project_resources, {kind: 'font'});
+        },
+        GetResources: function() {
+            return project_resources;
         },
         GetResourceByID: function(id) {
             return _.find(project_resources, function(resource) { return _.contains(resource.identifiers, id); });

--- a/ide/static/ide/js/sidebar.js
+++ b/ide/static/ide/js/sidebar.js
@@ -167,6 +167,7 @@ CloudPebble.Sidebar = (function() {
             $('#sidebar-pane-dependencies > a').click(CloudPebble.Dependencies.Show);
             $('#sidebar-pane-settings > a').click(CloudPebble.Settings.Show);
             $('#sidebar-pane-github > a').click(CloudPebble.GitHub.Show);
+            $('#sidebar-pane-media > a').click(CloudPebble.PublishedMedia.Show);
             $('#sidebar-pane-timeline > a').click(CloudPebble.Timeline.show);
             create_initial_sections(CloudPebble.ProjectInfo.type);
         },

--- a/ide/static/ide/js/ycm.js
+++ b/ide/static/ide/js/ycm.js
@@ -261,6 +261,12 @@ CloudPebble.YCM = new (function() {
         })
     };
 
+    this.updatePublishedMedia = function(published_media) {
+        return ws_send('published_media', {
+            'published_media': _.pluck(published_media, 'name')
+        });
+    };
+
     this.request = function(endpoint, editor, cursor) {
         var init_step = Promise.resolve();
         if (mFailed) {

--- a/ide/tasks/archive.py
+++ b/ide/tasks/archive.py
@@ -191,12 +191,13 @@ def do_import_archive(project_id, archive, delete_project=False):
 
                 with transaction.atomic():
                     # We have a resource map! We can now try importing things from it.
-                    project_options, media_map, dependencies = load_manifest_dict(manifest_dict, manifest_kind)
+                    project_options, media_map, dependencies, published_media = load_manifest_dict(manifest_dict, manifest_kind)
 
                     for k, v in project_options.iteritems():
                         setattr(project, k, v)
                     project.full_clean()
                     project.set_dependencies(dependencies)
+                    project.set_published_media(published_media)
 
                     RES_PATH = project.resources_path
 

--- a/ide/tasks/gist.py
+++ b/ide/tasks/gist.py
@@ -69,7 +69,7 @@ def import_gist(user_id, gist_id):
         package.update(content)
         package['pebble'] = defaultdict(lambda: None)
         package['pebble'].update(content.get('pebble', {}))
-        manifest_settings, media, dependencies = load_manifest_dict(package, PACKAGE_MANIFEST, default_project_type=None)
+        manifest_settings, media, dependencies, published_media = load_manifest_dict(package, PACKAGE_MANIFEST, default_project_type=None)
         default_settings['app_keys'] = '[]'
         default_settings['sdk_version'] = '3'
         default_settings['app_modern_multi_js'] = True
@@ -77,10 +77,11 @@ def import_gist(user_id, gist_id):
         content = json.loads(files[APPINFO_MANIFEST].content)
         package = defaultdict(lambda: None)
         package.update(content)
-        manifest_settings, media, dependencies = load_manifest_dict(package, APPINFO_MANIFEST, default_project_type=None)
+        manifest_settings, media, dependencies, published_media = load_manifest_dict(package, APPINFO_MANIFEST, default_project_type=None)
     else:
         manifest_settings = {}
         dependencies = {}
+        published_media = []
 
     fixed_settings = {
         'owner': user,
@@ -95,6 +96,7 @@ def import_gist(user_id, gist_id):
     with transaction.atomic():
         project = Project.objects.create(**project_settings)
         project.set_dependencies(dependencies)
+        project.set_published_media(published_media)
         project_type = project.project_type
 
         if project_type == 'package':

--- a/ide/templates/ide/project.html
+++ b/ide/templates/ide/project.html
@@ -65,7 +65,7 @@
                     <li class="nav-header" id="sidebar-pane-settings"><a href="#">{% trans 'Settings' %}</a></li>
                     <li class="nav-header sdk3-only" id="sidebar-pane-timeline"><a href="#">Timeline (Preview)</a></li>
                     <li class="nav-header" id="sidebar-pane-compile"><a href="#">{% trans 'Compilation' %}</a></li>
-                    <li class="nav-header" id="sidebar-pane-media"><a href="#">{% trans 'Published Media' %}</a>
+                    <li class="nav-header sdk3-only native-only" id="sidebar-pane-media"><a href="#">{% trans 'Published Media' %}</a>
                         <span class="sidebar-error hide"></span>
                     </li>
                     {% if project.project_type == 'package' or project.project_type == 'native' %}

--- a/ide/templates/ide/project.html
+++ b/ide/templates/ide/project.html
@@ -65,6 +65,7 @@
                     <li class="nav-header" id="sidebar-pane-settings"><a href="#">{% trans 'Settings' %}</a></li>
                     <li class="nav-header sdk3-only" id="sidebar-pane-timeline"><a href="#">Timeline (Preview)</a></li>
                     <li class="nav-header" id="sidebar-pane-compile"><a href="#">{% trans 'Compilation' %}</a></li>
+                    <li class="nav-header" id="sidebar-pane-media"><a href="#">{% trans 'Published Media' %}</a></li>
                     {% if project.project_type == 'package' or project.project_type == 'native' %}
                         <li class="nav-header sdk3-only" id="sidebar-pane-dependencies"><a href="#">{% trans 'Dependencies' %}</a>
                             <span class="spinner spinner-dark hide"></span>
@@ -140,6 +141,7 @@
 {% include "ide/project/ui-editor.html" %}
 {% include "ide/project/timeline.html" %}
 {% include "ide/project/dependencies.html" %}
+{% include "ide/project/published_media.html" %}
 {% endblock %}
 
 {% block modals %}
@@ -587,6 +589,7 @@ var REGEXES = _.mapObject(JSON.parse('{{regexes_json|escapejs}}'), function(v) {
 <script src="{% static 'ide/js/compile.js' %}" type="text/javascript"></script>
 <script src="{% static 'ide/js/dependencies.js' %}" type="text/javascript"></script>
 <script src="{% static 'ide/js/resources.js' %}" type="text/javascript"></script>
+<script src="{% static 'ide/js/published_media.js' %}" type="text/javascript"></script>
 <script src="{% static 'ide/js/textext_tagger.js' %}" type="text/javascript"></script>
 <script src="{% static 'ide/js/KVtable.js' %}" type="text/javascript"></script>
 <script src="{% static 'ide/js/settings.js' %}" type="text/javascript"></script>

--- a/ide/templates/ide/project.html
+++ b/ide/templates/ide/project.html
@@ -65,7 +65,9 @@
                     <li class="nav-header" id="sidebar-pane-settings"><a href="#">{% trans 'Settings' %}</a></li>
                     <li class="nav-header sdk3-only" id="sidebar-pane-timeline"><a href="#">Timeline (Preview)</a></li>
                     <li class="nav-header" id="sidebar-pane-compile"><a href="#">{% trans 'Compilation' %}</a></li>
-                    <li class="nav-header" id="sidebar-pane-media"><a href="#">{% trans 'Published Media' %}</a></li>
+                    <li class="nav-header" id="sidebar-pane-media"><a href="#">{% trans 'Published Media' %}</a>
+                        <span class="sidebar-error hide"></span>
+                    </li>
                     {% if project.project_type == 'package' or project.project_type == 'native' %}
                         <li class="nav-header sdk3-only" id="sidebar-pane-dependencies"><a href="#">{% trans 'Dependencies' %}</a>
                             <span class="spinner spinner-dark hide"></span>

--- a/ide/templates/ide/project/published_media.html
+++ b/ide/templates/ide/project/published_media.html
@@ -16,7 +16,7 @@
     <div class="control-group">
         <label class="control-label">{% trans 'Identifier' %}</label>
         <div class="controls">
-            <input type="text" class="edit-media-name" placeholder="EXAMPLE_ICON" pattern="[A-Za-z0-9_]+">
+            <input type="text" class="edit-media-name" placeholder="EXAMPLE_MEDIA_NAME" pattern="{{ regexes.c_identifier }}">
             <span class="help-block">{% trans 'This is used in your code and must be a valid C identifier.' %}</span>
         </div>
     </div>

--- a/ide/templates/ide/project/published_media.html
+++ b/ide/templates/ide/project/published_media.html
@@ -5,7 +5,11 @@
     <form class="form-horizontal">
     </form>
 
-    <div class="well media-tool-buttons">
+    <div class="well media-pane-loading">
+        <h2>{% trans 'Loading...' %}</h2>
+    </div>
+
+    <div class="well hide media-tool-buttons">
         <button type="button" class="btn" id="add-published-media">
             {% trans 'Add New Published Media' %}
         </button>

--- a/ide/templates/ide/project/published_media.html
+++ b/ide/templates/ide/project/published_media.html
@@ -5,9 +5,9 @@
     <form class="form-horizontal">
     </form>
 
-    <div class="well">
+    <div class="well media-tool-buttons">
         <button type="button" class="btn" id="add-published-media">
-            <span class="non-font-only">{% trans 'Add New' %}</span>
+            {% trans 'Add New Published Media' %}
         </button>
     </div>
 </div>
@@ -20,25 +20,24 @@
             <span class="help-block">{% trans 'This is used in your code and must be a valid C identifier.' %}</span>
         </div>
     </div>
-    <div class="control-group">
+    <div class="control-group edit-media-id-group">
         <label class="control-label">{% trans 'Numeric ID' %}</label>
         <div class="controls">
-            <input type="number" class="edit-media-id" min="0" value="0"/>
-            <span class="help-block">{% trans 'Insert explanation here' %}</span>
+            <input type="number" class="edit-media-id" min="1" value="1"/>
+            <span class="help-block">{% trans 'Each Published media item must have a unique ID.' %}</span>
         </div>
     </div>
-    <div class="control-group">
+    <div class="control-group edit-media-glance-group">
         <label class="control-label">{% trans 'Glance' %}</label>
         <div class="controls">
             <select class="edit-media-glance media-resource-selector media-optional-selector"></select>
-            <span class="help-block">{% trans 'Insert explanation here' %}</span>
+            <span class="help-block">{% trans 'This references the image which will be displayed if this Published Media is used as the icon of an AppGlanceSlice.' %}</span>
         </div>
     </div>
-    <div class="control-group controls">
-        <label style="width: 250px" class="control-label">{% trans 'Specify Timeline Icons' %}
-            <span class="text-icon" data-content="{% trans 'Insert explanation here' %}">?</span>
-        </label>
+    <div class="control-group controls edit-media-timeline-group">
+        <label style="width: 250px" class="control-label">{% trans 'Specify Timeline Icons' %}</label>
         <input type="checkbox" class="edit-media-timeline form-section-toggle"> <p></p>
+        <span class="help-block">{% trans 'This references the resource images which will be displayed if this Published Media is used for the various sizes of a timeline icon. Tiny, small and large must have sizes of 25x25, 50x50 and 80x80 respectively.' %}</span>
 
         <div class="form-toggleable-section">
             <div class="edit-media-timeline-options">
@@ -59,4 +58,5 @@
             </div>
         </div>
     </div>
+    <button type="button" class="btn btn-danger btn-small btn-delete-well">{% trans 'Delete' %}</button>
 </div>

--- a/ide/templates/ide/project/published_media.html
+++ b/ide/templates/ide/project/published_media.html
@@ -1,0 +1,62 @@
+{% load i18n %}
+<!-- Compilation pane -->
+<div id="media-pane-template" class="hide media-pane resource-pane">
+    <div class="well alert alert-error hide"></div>
+    <form class="form-horizontal">
+    </form>
+
+    <div class="well">
+        <button type="button" class="btn" id="add-published-media">
+            <span class="non-font-only">{% trans 'Add New' %}</span>
+        </button>
+    </div>
+</div>
+
+<div class="well hide media-item" id="media-item-template" >
+    <div class="control-group">
+        <label class="control-label">{% trans 'Identifier' %}</label>
+        <div class="controls">
+            <input type="text" class="edit-media-name" placeholder="EXAMPLE_ICON" pattern="[A-Za-z0-9_]+">
+            <span class="help-block">{% trans 'This is used in your code and must be a valid C identifier.' %}</span>
+        </div>
+    </div>
+    <div class="control-group">
+        <label class="control-label">{% trans 'Numeric ID' %}</label>
+        <div class="controls">
+            <input type="number" class="edit-media-id" min="0" value="0"/>
+            <span class="help-block">{% trans 'Insert explanation here' %}</span>
+        </div>
+    </div>
+    <div class="control-group">
+        <label class="control-label">{% trans 'Glance' %}</label>
+        <div class="controls">
+            <select class="edit-media-glance media-resource-selector media-optional-selector"></select>
+            <span class="help-block">{% trans 'Insert explanation here' %}</span>
+        </div>
+    </div>
+    <div class="control-group controls">
+        <label style="width: 250px" class="control-label">{% trans 'Specify Timeline Icons' %}
+            <span class="text-icon" data-content="{% trans 'Insert explanation here' %}">?</span>
+        </label>
+        <input type="checkbox" class="edit-media-timeline form-section-toggle"> <p></p>
+
+        <div class="form-toggleable-section">
+            <div class="edit-media-timeline-options">
+                <br/>
+
+                <div class="control-group">
+                    <label class="control-label">{% trans 'Tiny' %}</label>
+                    <select class="edit-media-timeline-tiny media-resource-selector"></select>
+                </div>
+                <div class="control-group">
+                    <label class="control-label">{% trans 'Small' %}</label>
+                    <select class="edit-media-timeline-small media-resource-selector"></select>
+                </div>
+                <div class="control-group">
+                    <label class="control-label">{% trans 'Large' %}</label>
+                    <select class="edit-media-timeline-large media-resource-selector"></select>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/ide/templates/ide/project/published_media.html
+++ b/ide/templates/ide/project/published_media.html
@@ -2,18 +2,23 @@
 <!-- Compilation pane -->
 <div id="media-pane-template" class="hide media-pane resource-pane">
     <div class="well alert alert-error hide"></div>
-    <form class="form-horizontal">
-    </form>
+    <form>
+    <div id="media-items" class="form-horizontal">
 
+    </div>
     <div class="well media-pane-loading">
         <h2>{% trans 'Loading...' %}</h2>
     </div>
 
     <div class="well hide media-tool-buttons">
+        <button type="submit" class="btn btn-affirmative" id="save-published-media">
+            {% trans 'Save' %}
+        </button>
         <button type="button" class="btn" id="add-published-media">
             {% trans 'Add New Published Media' %}
         </button>
     </div>
+    </form>
 </div>
 
 <div class="well hide media-item" id="media-item-template" >

--- a/ide/templates/ide/project/resource.html
+++ b/ide/templates/ide/project/resource.html
@@ -11,7 +11,7 @@
                         <option value="bitmap">{% trans 'Bitmap Image' %}</option>
                         {% if project.is_standard_project_type  %}
                             <option value="font">{% trans 'TrueType font' %}</option>
-                            <option value="raw">{% trans 'Raw binary blob' %}</option>
+                            <option value="raw">{% trans 'Raw binary blob' %}</option>w
                         {% endif %}
 
                         <option value="png">{% trans 'PNG image (deprecated)' %}</option>
@@ -115,11 +115,11 @@
                 <div class="resource-targets-section sdk3-only native-only">
                     <div class="control-group controls">
                         <label style="width: 250px" class="control-label">{% trans 'Target platforms' %}
-                            <span class="text-icon" data-content="{% trans "Use the Target Platforms option when you want a specific resource ID to only be available for specific platforms. <br> If you want this resource to be available on multiple platforms but with different files, upload additional images and tag them." %}">?</span>
+                            <span class="text-icon" data-content="{% trans 'Use the Target Platforms option when you want a specific resource ID to only be available for specific platforms. <br> If you want this resource to be available on multiple platforms but with different files, upload additional images and tag them.' %}">?</span>
                         </label>
-                        <input type="checkbox" class="edit-resource-target-platforms-enabled"> <p></p>
+                        <input type="checkbox" class="form-section-toggle"> <p></p>
 
-                        <div class="edit-resource-targets">
+                        <div class="form-toggleable-section">
                             <div class="edit-resource-target-options">
                                 <br/>
                             {% for platform in  supported_platforms %}

--- a/ide/tests/test_import_archive.py
+++ b/ide/tests/test_import_archive.py
@@ -180,6 +180,27 @@ class TestImportArchive(CloudpebbleTestCase):
         self.assertEqual(project.source_files.filter(file_name='lib.js', target='common').count(), 1)
         self.assertEqual(project.source_files.filter(file_name='app.js', target='pkjs').count(), 1)
 
+    def test_import_published_media(self):
+        published_media = [{
+            'name': 'TEST',
+            'id': 0,
+            'glance': 'TINY',
+            'timeline': {
+                'tiny': 'TINY',
+                'small': 'SMALL',
+                'large': 'LARGE',
+            }
+        }]
+        bundle = build_bundle({
+            'src/main.c': '',
+            'package.json': make_package(pebble_options={
+                'publishedMedia': published_media
+            })
+        })
+        do_import_archive(self.project_id, bundle)
+        project = Project.objects.get(pk=self.project_id)
+        self.assertEqual(project.get_published_media(), published_media)
+
 
 @mock.patch('ide.models.s3file.s3', fake_s3)
 class TestImportLibrary(CloudpebbleTestCase):

--- a/ide/tests/test_manifest_generation.py
+++ b/ide/tests/test_manifest_generation.py
@@ -75,3 +75,22 @@ class TestNPMStyleManifestGeneration(ManifestTester):
         }
         manifest = generate_manifest(self.project, [])
         self.check_package_manifest(manifest, package_options={'dependencies': deps})
+
+    def test_published_media(self):
+        """ Check that publishedMedia are represented in the manifest """
+        published_media = [{
+            'name': 'TEST',
+            'id': 0,
+            'glance': 'TINY',
+            'timeline': {
+                'tiny': 'TINY',
+                'small': 'SMALL',
+                'large': 'LARGE',
+            }
+        }]
+        self.project.set_published_media(published_media)
+        manifest = generate_manifest(self.project, [])
+        self.check_package_manifest(manifest, pebble_options={
+            'publishedMedia': published_media
+        })
+

--- a/ide/urls.py
+++ b/ide/urls.py
@@ -5,7 +5,7 @@ from ide.api.git import github_push, github_pull, set_project_repo, create_proje
 from ide.api.phone import ping_phone, check_phone, list_phones, update_phone
 from ide.api.project import project_info, compile_project, last_build, build_history, build_log, create_project, \
     save_project_settings, save_project_dependencies, delete_project, begin_export, import_zip, import_github, do_import_gist, \
-    get_projects
+    get_projects, save_published_media
 from ide.api.resource import create_resource, resource_info, delete_resource, update_resource, show_resource, \
     delete_variant
 from ide.api.source import create_source_file, load_source_file, source_file_is_safe, save_source_file, \
@@ -28,6 +28,7 @@ urlpatterns = patterns(
     url(r'^project/(?P<project_id>\d+)/info', project_info, name='project_info'),
     url(r'^project/(?P<project_id>\d+)/save_settings', save_project_settings, name='save_project_settings'),
     url(r'^project/(?P<project_id>\d+)/save_dependencies', save_project_dependencies, name='save_project_dependencies'),
+    url(r'^project/(?P<project_id>\d+)/save_published_media', save_published_media, name='save_published_media'),
     url(r'^project/(?P<project_id>\d+)/delete', delete_project, name='delete_project'),
     url(r'^project/(?P<project_id>\d+)/create_source_file', create_source_file, name='create_source_file'),
     url(r'^project/(?P<project_id>\d+)/source/(?P<file_id>\d+)/load', load_source_file, name='load_source_file'),

--- a/ide/utils/regexes.py
+++ b/ide/utils/regexes.py
@@ -9,7 +9,7 @@ class RegexHolder(object):
         # Match major.minor.0, where major and minor are numbers between 0 and 255 with no leading 0s
         'semver': r'^(0|[1-9]\d?|1\d{2}|2[0-4]\d|25[0-5])\.(0|[1-9]\d?|1\d{2}|2[0-4]\d|25[0-5])\.0$',
 
-        # Match a string of letters and numbers separated with underscores but not starting with a digit
+        # Match a string of letters and numbers separated with underscores
         'c_identifier': r'^\w+$',
 
         # Match a C identifier optionally followed by an [array index]

--- a/ide/utils/sdk/manifest.py
+++ b/ide/utils/sdk/manifest.py
@@ -86,6 +86,9 @@ def generate_v3_manifest_dict(project, resources):
         manifest['pebble']['displayName'] = project.app_long_name
         if project.app_is_hidden:
             manifest['pebble']['watchapp']['hiddenApp'] = project.app_is_hidden
+    published_media = project.get_published_media()
+    if published_media:
+        manifest['pebble']['publishedMedia'] = published_media
     if project.app_platforms:
         manifest['pebble']['targetPlatforms'] = project.app_platform_list
     return manifest
@@ -271,6 +274,7 @@ def load_manifest_dict(manifest, manifest_kind, default_project_type='native'):
     """
     project = {}
     dependencies = {}
+    published_media = []
     if manifest_kind == APPINFO_MANIFEST:
         project['app_short_name'] = manifest['shortName']
         project['app_long_name'] = manifest['longName']
@@ -289,8 +293,10 @@ def load_manifest_dict(manifest, manifest_kind, default_project_type='native'):
         project['keywords'] = manifest.get('keywords', [])
         dependencies = manifest.get('dependencies', {})
         manifest = manifest['pebble']
+        published_media = manifest.get('publishedMedia', [])
         project['app_modern_multi_js'] = manifest.get('enableMultiJS', True)
         project['sdk_version'] = manifest.get('sdkVersion', '3')
+
     else:
         raise InvalidProjectArchiveException(_('Invalid manifest kind: %s') % manifest_kind[-12:])
 
@@ -307,4 +313,4 @@ def load_manifest_dict(manifest, manifest_kind, default_project_type='native'):
     else:
         media_map = {}
     project['project_type'] = manifest.get('projectType', default_project_type)
-    return project, media_map, dependencies
+    return project, media_map, dependencies, published_media


### PR DESCRIPTION
This PR adds support to CloudPebble for publishedMedia.

The basic interface looks like this. It is only available for Native SDK 4 projects (and not packages).
![screen shot 2016-08-18 at 18 46 45](https://cloud.githubusercontent.com/assets/141427/17796595/7dcea482-6576-11e6-863c-7b918155a6ba.png)
It has the following behaviours:

- Toggling "Specify Timeline Icons" shows or hides the 'tiny/small/large' menus.
- Glance has an extra option called "-- None --" which removes it from 
- Selecting a resource ID for "Glance" while timeline is enabled will change tiny with it
- Each Select element presents a set of resource IDs (image or raw) which combines
  - Your own own project's resources
  - Any resource IDs in dependencies (updated whenever dependencies are changed)


The form auto-saves whenever it is in a valid state, and it doesn't disrupt the user with errors while editing. If the user isn't sure why the form isn't saving, they will probably try submitting the form by pressing enter or clicking the save button, at which point they will actually be shown an error message which disappears as soon as the user resolves the error.

![screen shot 2016-08-18 at 18 40 48](https://cloud.githubusercontent.com/assets/141427/17797235/406e366a-657c-11e6-8a64-8bacf80e727c.png)

Only the first item has the help text - the rest look like this:
![screen shot 2016-08-18 at 19 36 12](https://cloud.githubusercontent.com/assets/141427/17797220/1a37b52a-657c-11e6-9d61-ee83967e7b0b.png)

The "Add New Published Media" button adds a new section, with a numeric ID of max(ids)+1.

When you rename your own project's resource IDs, CloudPebble attempts to figure out what was renamed to what, and then rename the corresponding publishedMedia entry. In 99% of cases (i.e. a resource ID which was unique was renamed to something else) this will be successful.

However, there are a number of possible actions which can result in publishedMedia referencing ResourceIDs which no longer exist, and when this happens an icon will appear next to the sidebar menu
![screen shot 2016-08-18 at 18 39 47](https://cloud.githubusercontent.com/assets/141427/17797363/1fcfb2b6-657d-11e6-8137-2af7aa434ee6.png)
These actions include:

- A publishedMedia references duplicated ResourceIDs, and both ResourceIDs are _simultaneously_ renamed to different things.
- A publishedMedia references a ResourceID which is deleted.
- A publishedMedia references a ResourceID from a dependency which no longer exists or no longer has the resource.
- A publishedMedia references a ResourceID which doesn't exist because it was imported from github or a ZIP file.
