### PR TITLE
Fix building native projects with old-style JS

### DIFF
--- a/ide/utils/sdk/sdk_scripts.py
+++ b/ide/utils/sdk/sdk_scripts.py
@@ -298,9 +298,9 @@ def build(ctx):
 
     ctx.set_group('bundle')
     ctx.pbl_bundle(binaries=binaries, js=ctx.path.ant_glob(['src/pkjs/**/*.js', 'src/pkjs/**/*.json']), js_entry_file='src/pkjs/{{pkjs_entry}}')
-"""
+""".replace('{{pkjs_entry}}', project.pkjs_entry_point)
 
-    return wscript.replace('{{jshint}}', 'True' if jshint and not for_export else 'False').replace('{{pkjs_entry}}', project.pkjs_entry_point)
+    return wscript.replace('{{jshint}}', 'True' if jshint and not for_export else 'False')
 
 
 def generate_wscript_file(project, for_export=False):

--- a/ide/utils/sdk/sdk_scripts.py
+++ b/ide/utils/sdk/sdk_scripts.py
@@ -298,9 +298,8 @@ def build(ctx):
 
     ctx.set_group('bundle')
     ctx.pbl_bundle(binaries=binaries, js=ctx.path.ant_glob(['src/pkjs/**/*.js', 'src/pkjs/**/*.json']), js_entry_file='src/pkjs/{{pkjs_entry}}')
-""".replace('{{pkjs_entry}}', project.pkjs_entry_point)
-
-    return wscript.replace('{{jshint}}', 'True' if jshint and not for_export else 'False')
+"""
+    return wscript.replace('{{jshint}}', 'True' if jshint and not for_export else 'False').replace('{{pkjs_entry}}', project.pkjs_entry_point or '')
 
 
 def generate_wscript_file(project, for_export=False):

--- a/ide/utils/sdk/sdk_scripts.py
+++ b/ide/utils/sdk/sdk_scripts.py
@@ -292,7 +292,7 @@ def build(ctx):
         if build_worker:
             worker_elf = '{}/pebble-worker.elf'.format(ctx.env.BUILD_DIR)
             binaries.append({'platform': p, 'app_elf': app_elf, 'worker_elf': worker_elf})
-            ctx.pbl_worker(source=ctx.path.ant_glob(['worker_src/c/**/*.c', 'src/js/**/*.json']), target=worker_elf)
+            ctx.pbl_worker(source=ctx.path.ant_glob('worker_src/c/**/*.c'), target=worker_elf)
         else:
             binaries.append({'platform': p, 'app_elf': app_elf})
 


### PR DESCRIPTION
This fixes a regression in the 4.0 release where building projects using JS concatenation would result in a
> TypeError: expected a string or other character buffer object
error.