### PR TITLE
Fix run button widths

### DIFF
--- a/ide/static/ide/css/ide.css
+++ b/ide/static/ide/css/ide.css
@@ -527,16 +527,22 @@ table.kv-table .kv-remove {
     margin-left: 110px;
 }
 
-.compilation-pane #run-on-phone .btn,
-.compilation-pane #run-on-qemu .btn,
-.compilation-pane .build-buttons .btn {
+.compilation-pane .compilation-buttons.two-buttons .btn {
+    width: 287px;
+    margin: 0 4px;
+}
+
+.compilation-pane .compilation-buttons.three-buttons .btn{
+    width: 188px;
+    margin-right: 9px;
+}
+
+.compilation-pane .compilation-buttons.four-buttons .btn{
     width: 137px;
     margin: 0 4px;
 }
 
-.compilation-pane #run-on-phone .btn:last-of-type,
-.compilation-pane #run-on-qemu .btn:last-of-type,
-.compilation-pane .build-buttons .btn:last-child {
+.compilation-pane .compilation-buttons .btn:last-child {
     margin-right: 0;
 }
 

--- a/ide/templates/ide/project/compile.html
+++ b/ide/templates/ide/project/compile.html
@@ -18,7 +18,7 @@
                         </div>
                         <hr>
 
-                        <div>
+                        <div class="compilation-buttons three-buttons">
                             <button class="btn btn-primary" id="install-on-phone-btn">{% trans 'Install and Run' %}</button>
                             <button class="btn" id="show-app-logs-btn">{% trans 'View app logs' %}</button>
                             <button class="btn" id="screenshot-btn">{% trans 'Screenshot' %}</button>
@@ -26,14 +26,14 @@
                     </div>
                     <div id="run-qemu" class="tab-pane active">
                         <hr>
-                        <div>
+                        <div class="compilation-buttons four-buttons">
                             <button class="btn btn-primary" id="install-in-qemu-aplite-btn" data-platform="aplite">Aplite</button>
                             <button class="btn btn-primary" id="install-in-qemu-basalt-btn" data-platform="basalt">Basalt</button>
                             <button class="btn btn-primary" id="install-in-qemu-chalk-btn" data-platform="chalk">Chalk</button>
                             <button class="btn btn-primary" id="install-in-qemu-diorite-btn" data-platform="diorite">Diorite</button>
                         </div>
                         <hr>
-                        <div>
+                        <div class="compilation-buttons two-buttons">
                             <button class="btn" id="show-qemu-logs-btn">{% trans 'View app logs' %}</button>
                             <button class="btn" id="screenshot-qemu-btn">{% trans 'Screenshot' %}</button>
                         </div>
@@ -57,7 +57,7 @@
             <p id="last-compilation-size-diorite" class="hide"><label>{% trans 'Diorite Size:' %}</label> <span class="text"></span></p>
         </div>
         <hr>
-        <div class="build-buttons">
+        <div class="compilation-buttons three-buttons">
             <button class="btn btn-affirmative" id="compilation-run-build-button">{% trans 'Run build' %}</button>
             <a id="last-compilation-pbw" href="#" class="btn hide">
                 {% if project.project_type == 'package'%}


### PR DESCRIPTION
This just fixes the button widths in the compile pane's run section, so that they're all fully justified.