### PR TITLE
Deal correctly with package versions.

### DIFF
--- a/ide/models/project.py
+++ b/ide/models/project.py
@@ -12,16 +12,9 @@ from ide.models.dependency import Dependency
 from ide.models.meta import IdeModel
 from ide.utils import generate_half_uuid
 from ide.utils.regexes import regexes
-from ide.utils.version import version_to_semver, semver_to_version, parse_sdk_version
+from ide.utils.version import version_to_semver, semver_to_version, parse_sdk_version, parse_semver
 
 __author__ = 'katharine'
-
-
-def version_validator(value):
-    try:
-        parse_sdk_version(value)
-    except ValueError:
-        raise ValidationError(_("Invalid version string. Versions should be major[.minor]."))
 
 
 class Project(IdeModel):
@@ -49,7 +42,7 @@ class Project(IdeModel):
     app_company_name = models.CharField(max_length=100, blank=True, null=True)
     app_short_name = models.CharField(max_length=100, blank=True, null=True)
     app_long_name = models.CharField(max_length=100, blank=True, null=True)
-    app_version_label = models.CharField(max_length=40, blank=True, null=True, default='1.0', validators=[version_validator])
+    app_version_label = models.CharField(max_length=40, blank=True, null=True, default='1.0')
     app_is_watchface = models.BooleanField(default=False)
     app_is_hidden = models.BooleanField(default=False)
     app_is_shown_on_communication = models.BooleanField(default=False)
@@ -89,6 +82,8 @@ class Project(IdeModel):
             self.app_keys = '[]'
         if self.sdk_version == '2':
             self.app_modern_multi_js = False
+        if self.project_type == 'package' and self.app_version_label == '1.0':
+            self.app_version_label = '1.0.0'
 
     def set_dependencies(self, dependencies):
         """ Set the project's dependencies from a dictionary.
@@ -177,12 +172,18 @@ class Project(IdeModel):
     @property
     def semver(self):
         """ Get the app's version label formatted as a semver """
-        return version_to_semver(self.app_version_label)
+        if self.project_type == 'package':
+            return self.app_version_label
+        else:
+            return version_to_semver(self.app_version_label)
 
     @semver.setter
     def semver(self, value):
         """ Set the app's version label from a semver string"""
-        self.app_version_label = semver_to_version(value)
+        if self.project_type == 'package':
+            self.app_version_label = value
+        else:
+            self.app_version_label = semver_to_version(value)
 
     @property
     def supported_platforms(self):
@@ -219,7 +220,16 @@ class Project(IdeModel):
         is_sdk_2 = self.sdk_version == "2"
         if is_sdk_2 and self.uses_array_message_keys:
             raise ValidationError(_("SDK2 appKeys must be an object, not a list."))
+        if self.project_type != 'package':
+            try:
+                parse_sdk_version(self.app_version_label)
+            except ValueError:
+                raise ValidationError(_("Invalid version string. Versions should be major[.minor]."))
         if self.project_type == 'package':
+            try:
+                parse_semver(self.app_version_label)
+            except ValueError:
+                raise ValidationError(_("Invalid version string. Versions should be major.minor.patch"))
             if is_sdk_2:
                 raise ValidationError(_("Packages are not available for SDK 2"))
             if not self.app_modern_multi_js:

--- a/ide/models/project.py
+++ b/ide/models/project.py
@@ -171,16 +171,26 @@ class Project(IdeModel):
 
     @property
     def semver(self):
-        """ Get the app's version label formatted as a semver """
+        """ Get the app's version label formatted as a semver. """
         if self.project_type == 'package':
-            return self.app_version_label
-        else:
-            return version_to_semver(self.app_version_label)
+            try:
+                # Packages should have semver app_versions_labels...
+                parse_semver(self.app_version_label)
+                return self.app_version_label
+            except ValueError as e:
+                # but if they don't, we try to convert it from an app-style version label.
+                try:
+                    version_to_semver(self.app_version_label)
+                except:
+                    raise e
+        return version_to_semver(self.app_version_label)
 
     @semver.setter
     def semver(self, value):
-        """ Set the app's version label from a semver string"""
+        """ Set the app's version label from a semver string. """
         if self.project_type == 'package':
+            # This throws an error if the semver is invalid.
+            parse_semver(value)
             self.app_version_label = value
         else:
             self.app_version_label = semver_to_version(value)

--- a/ide/static/ide/js/settings.js
+++ b/ide/static/ide/js/settings.js
@@ -111,8 +111,11 @@ CloudPebble.Settings = (function() {
             // This is not an appropriate use of a regex, but we have to have it for the HTML5 pattern attribute anyway,
             // so we may as well reuse the effort here.
             // It validates that the format matches x[.y] with x, y in [0, 255].
-            if(!version_label.match(REGEXES.sdk_version)) {
+            if(CloudPebble.ProjectInfo.type != 'package' && !version_label.match(REGEXES.sdk_version)) {
                 throw new Error(gettext("You must specify a valid version number."));
+            }
+            if(CloudPebble.ProjectInfo.type == 'package' && !version_label.match(REGEXES.semver)) {
+                throw new Error(gettext("You must specify a valid version semver."));
             }
             if(!app_uuid.match(REGEXES.uuid)) {
                 throw new Error(gettext("You must specify a valid UUID (of the form 00000000-0000-0000-0000-000000000000)"));

--- a/ide/templates/ide/project/settings.html
+++ b/ide/templates/ide/project/settings.html
@@ -147,11 +147,17 @@
                 <div class="control-group">
                     <label class="control-label" for="settings-version-label">{% trans "Version label" %}</label>
                     <div class="controls">
-                        <input type="text" id="settings-version-label" placeholder="0.1" value="{{project.app_version_label}}"
-                                pattern="{{ regexes.sdk_version }}">
-                        <span class="help-block">
-                            {% trans "App version. Takes the format major[.minor], where major and minor are between 0 and 255." %}
-                        </span>
+                        {% if project.project_type != 'package' %}
+                            <input type="text" id="settings-version-label" placeholder="0.1" value="{{project.app_version_label}}" pattern="{{ regexes.sdk_version }}">
+                            <span class="help-block">
+                                {% trans "App version. Takes the format major[.minor], where major and minor are between 0 and 255." %}
+                            </span>
+                        {% else %}
+                            <input type="text" id="settings-version-label" placeholder="0.1.0" value="{{project.app_version_label}}" pattern="{{ regexes.semver }}">
+                            <span class="help-block">
+                                {% trans "Pacakge version. Takes the format major.minor.patch, where each is a number between 0 and 255." %}
+                            </span>
+                        {% endif %}
                     </div>
                 </div>
                 <div class="control-group">

--- a/ide/templates/ide/project/settings.html
+++ b/ide/templates/ide/project/settings.html
@@ -153,7 +153,7 @@
                                 {% trans "App version. Takes the format major[.minor], where major and minor are between 0 and 255." %}
                             </span>
                         {% else %}
-                            <input type="text" id="settings-version-label" placeholder="0.1.0" value="{{project.app_version_label}}" pattern="{{ regexes.semver }}">
+                            <input type="text" id="settings-version-label" placeholder="0.1.0" value="{{project.semver}}" pattern="{{ regexes.semver }}">
                             <span class="help-block">
                                 {% trans "Pacakge version. Takes the format major.minor.patch, where each is a number between 0 and 255." %}
                             </span>

--- a/ide/tests/test_project_version.py
+++ b/ide/tests/test_project_version.py
@@ -22,11 +22,15 @@ class TestSemverConversion(TestCase):
             for y in range(256):
                 self.assertEqual(version.version_to_semver("{}.{}".format(x, y)), "{}.{}.0".format(x, y))
 
-    def test_all_semvers_to_version(self):
-        """ Check that all valid semvers validate and are converted to major.minor versions correctly """
+    def test_semvers_to_version(self):
+        """ Check that valid x.y.0 semvers validate and are converted to major.minor versions correctly """
         for x in range(256):
             for y in range(256):
                 self.assertEqual(version.semver_to_version("{}.{}.0".format(x, y)), "{}.{}".format(x, y))
+
+    def test_semvers_discard_patch(self):
+        """ Check that semver_to_version() discards the patch number. """
+        self.assertEqual(version.semver_to_version("1.2.3"), "1.2")
 
     def test_invalid_versions(self):
         """ Throw errors for a variety of invalid SDK version strings """
@@ -41,7 +45,6 @@ class TestSemverConversion(TestCase):
 
     def test_invalid_semvers(self):
         """ Throw errors for a variety of invalid pebble-compatible semver strings """
-        self.run_invalid_semver_test("1.0.1")
         self.run_invalid_semver_test("01.1.4")
         self.run_invalid_semver_test("300.0.1")
         self.run_invalid_semver_test("6.9")

--- a/ide/utils/cloudpebble_test.py
+++ b/ide/utils/cloudpebble_test.py
@@ -35,7 +35,7 @@ class CloudpebbleTestCase(TestCase):
         if project_options:
             create_data.update(project_options)
         new_project = json.loads(self.client.post('/ide/project/create', create_data).content)
-        self.assertTrue(new_project['success'])
+        self.assertTrue(new_project['success'], msg=new_project.get('error', None))
         self.project_id = new_project['id']
 
 

--- a/ide/utils/regexes.py
+++ b/ide/utils/regexes.py
@@ -6,8 +6,8 @@ class RegexHolder(object):
         # Match major[.minor], where major and minor are numbers between 0 and 255 with no leading 0s
         'sdk_version': r'^(0|[1-9]\d?|1\d{2}|2[0-4]\d|25[0-5])(\.(0|[1-9]\d?|1\d{2}|2[0-4]\d|25[0-5]))?$',
 
-        # Match major.minor.0, where major and minor are numbers between 0 and 255 with no leading 0s
-        'semver': r'^(0|[1-9]\d?|1\d{2}|2[0-4]\d|25[0-5])\.(0|[1-9]\d?|1\d{2}|2[0-4]\d|25[0-5])\.0$',
+        # Match x.y.z, each a number between 0 and 255 with no leading 0s
+        'semver': r'^(0|[1-9]\d?|1\d{2}|2[0-4]\d|25[0-5])\.(0|[1-9]\d?|1\d{2}|2[0-4]\d|25[0-5])\.(0|[1-9]\d?|1\d{2}|2[0-4]\d|25[0-5])$',
 
         # Match a string of letters and numbers separated with underscores but not starting with a digit
         'c_identifier': r'^\w+$',

--- a/ide/utils/version.py
+++ b/ide/utils/version.py
@@ -32,7 +32,7 @@ def parse_semver(semver):
     parsed = re.match(regexes.SEMVER, semver)
     if not parsed:
         raise ValueError("Invalid semver {}".format(semver))
-    return parsed.group(1), parsed.group(2)
+    return parsed.group(1), parsed.group(2), parsed.group(3)
 
 
 def semver_to_version(semver):
@@ -40,4 +40,5 @@ def semver_to_version(semver):
     :param semver: should be major.minor.0
     :return: "major.minor"
     """
-    return "{}.{}".format(*parse_semver(semver))
+    major, minor, patch = parse_semver(semver)
+    return "{}.{}".format(major, minor)

--- a/ide/utils/version.py
+++ b/ide/utils/version.py
@@ -26,7 +26,7 @@ def version_to_semver(version):
 
 def parse_semver(semver):
     """ Parse a pebble/npm compatible semver
-    :param semver: should be "major.minor.0"
+    :param semver: should be "major.minor.patch"
     :return: (major, minor)
     """
     parsed = re.match(regexes.SEMVER, semver)


### PR DESCRIPTION
Packages are supposed to actually use semvers, but CloudPebble didn't support this correctly. This PR corrects the backend/UI so that packages are allowed to use full semvers but apps still require major.minor.