### PR TITLE
Fix KV-table row delete regression

### DIFF
--- a/ide/static/ide/js/KVtable.js
+++ b/ide/static/ide/js/KVtable.js
@@ -54,10 +54,10 @@ CloudPebble.KVTable = function(table_elm, options) {
                     .attr('placeholder', key ? null : opts.value_placeholder)),
             $('<td>').append(
                 $('<button>')
-                    .prop('disabled', !key))
+                    .prop('disabled', !key)
                     .text('-')
                     .addClass("btn kv-remove")
-                    .attr('type', 'button')
+                    .attr('type', 'button'))
         ]);
         self.trigger('rowRendered', row);
         return row;

--- a/ide/static/ide/js/dependencies.js
+++ b/ide/static/ide/js/dependencies.js
@@ -279,6 +279,7 @@ CloudPebble.Dependencies = (function() {
             if (!val) return;
             cache.lookup_module(val).then(function(data) {
                 on_submit(val, data.version ? version_prefix + data.version : null);
+                return null;
             }).catch(function() {
                 on_submit(val, null);
             });


### PR DESCRIPTION
This corrects a typo in #325 and also adds a `return null` to remove a Bluebird warning.