### PR TITLE
Remove the duplicated 'Compilation' shortcut.

### DIFF
--- a/ide/static/ide/js/compile.js
+++ b/ide/static/ide/js/compile.js
@@ -179,7 +179,6 @@ CloudPebble.Compile = (function() {
         commands[gettext("Show Phone Logs")] = function() { show_app_logs(ConnectionType.Phone); };
         commands[gettext("Show Emulator Logs")] = function() { show_app_logs(ConnectionType.Qemu); };
         commands[gettext("Show Last Build Log")] = function() {show_build_log(mLastBuild.id)};
-        commands[gettext("Compilation")] = function() { show_compile_pane();};
         commands[gettext("Clear App Logs")] = function() { show_clear_logs_prompt(); };
         commands[gettext("Take Screenshot")] = function() { take_screenshot(); };
         CloudPebble.FuzzyPrompt.AddCommands(commands);


### PR DESCRIPTION
Pressing Cmd-Shift-P and typing "Compilation" shows you two identical shortcuts to the compilation pane. This PR removes the duplicate in `compile.js`, since [settings.js](https://github.com/pebble/cloudpebble/blob/86fb8be6f1dfb1e067e6fafa5da1cbfc5f361485/ide/static/ide/js/settings.js#L408) is where all sidebar fuzzy-shortcuts are defined.