### PR TITLE
Allow - and . in log filenames.

### DIFF
--- a/ide/static/ide/js/compile.js
+++ b/ide/static/ide/js/compile.js
@@ -62,7 +62,7 @@ CloudPebble.Compile = (function() {
             log = log.replace(/^(src\/js\/.*)$/gm, '<span class="log-error">$1</span>');
             log = log.replace(/^(JavaScript linting failed.*)$/gm, '<span class="log-note">$1</span>');
             // Link the thingies.
-            log = log.replace(/([\/a-zA-Z0-9_]+\.[ch]):([0-9+]+)/g, '<span class="filename-link" data-filename="$1" data-line="$2">$1:$2</span>');
+            log = log.replace(/([\/.]*)([\/a-zA-Z0-9_.-]+\.[ch]):([0-9+]+)/g, '<span class="filename-link" data-filename="$2" data-line="$3">$1$2:$3</span>');
             log = '<pre class="build-log">' + log + '</pre>';
             log = $(log).css({'height': '100%', 'overflow': 'auto'});
             // Make the links do something.
@@ -366,7 +366,7 @@ CloudPebble.Compile = (function() {
                 append_log_html($('<hr>'));
             } else {
                 var display = _.escape(get_log_label(log.priority) + ' ' + log.filename + ':' + log.line_number + ': ' + log.message);
-                display = display.replace(/([\/a-zA-Z0-9_]+\.[ch]):([0-9+]+)/, '<span class="filename-link" data-filename="$1" data-line="$2">$1:$2</span>');
+                display = display.replace(/([\/.]*)([\/a-zA-Z0-9_.-]+\.[ch]):([0-9+]+)/, '<span class="filename-link" data-filename="$2" data-line="$3">$1$2:$3</span>');
                 var span = $('<span>').addClass(get_log_class(log.priority)).addClass('log').html(display);
                 span.find('.filename-link').click(function() {
                     var thing = $(this);


### PR DESCRIPTION
This PR fixes a bug where build/run log entries would not correctly link to files with with `.` or `-` in their names.

<img width="275" alt="screen shot 2016-09-02 at 13 33 43" src="https://cloud.githubusercontent.com/assets/141427/18217997/c858a1e8-7114-11e6-9464-1aea088a0d86.png">
<img width="282" alt="screen shot 2016-09-02 at 13 34 14" src="https://cloud.githubusercontent.com/assets/141427/18217998/c86d3644-7114-11e6-812c-1f6d687abd64.png">
<img width="201" alt="screen shot 2016-09-02 at 13 52 55" src="https://cloud.githubusercontent.com/assets/141427/18217999/c8703bfa-7114-11e6-943b-9290a2efb9f7.png">
<img width="190" alt="screen shot 2016-09-02 at 13 53 30" src="https://cloud.githubusercontent.com/assets/141427/18218000/c870e42e-7114-11e6-833f-9572d5ed82ce.png">
