### PR TITLE
Remove archive.py:ends_with_any()

### DIFF
--- a/ide/tasks/archive.py
+++ b/ide/tasks/archive.py
@@ -129,10 +129,6 @@ class ArchiveProjectItem(BaseProjectItem):
         return self.entry.filename
 
 
-def ends_with_any(s, options):
-    return any(s.endswith(end) for end in options)
-
-
 @task(acks_late=True)
 def do_import_archive(project_id, archive, delete_project=False):
     project = Project.objects.get(pk=project_id)


### PR DESCRIPTION
`ends_with_any()` is unused (`"string".endswith(tuple, ...)` does the same thing)