### PR TITLE
IPD-51633: login redirects to http instead of https

### DIFF
--- a/cloudpebble/settings.py
+++ b/cloudpebble/settings.py
@@ -20,7 +20,11 @@ ADMINS = (
 
 DEFAULT_FROM_EMAIL = _environ.get('FROM_EMAIL', 'CloudPebble <cloudpebble@example.com>')
 
-SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+ON_CLOUDFLARE = _environ.get('CLOUDFLARE') != ''
+if ON_CLOUDFLARE:
+    SECURE_PROXY_SSL_HEADER = ('HTTP_CF_VISITOR', '{"scheme":"https"}')
+else:
+    SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
 MANAGERS = ADMINS
 


### PR DESCRIPTION
By looking for a different header, we can convince django that we are in fact running over HTTPS and that there is no need to redirect to HTTP at any point.

Needs new config var `"CLOUDFLARE", "yes"` (already set for beta + production).

Tested on beta (for real, this time)!